### PR TITLE
enabling m1.small to be used as an instance type. in cloud deployments (...

### DIFF
--- a/lib/parse_args.rb
+++ b/lib/parse_args.rb
@@ -292,7 +292,7 @@ module ParseArgs
       val_hash['machine'] = ENV['APPSCALE_MACHINE']
     end 
 
-    possible_instance_types = ["m1.large", "m1.xlarge", "c1.xlarge"]
+    possible_instance_types = ["m1.small", "m1.large", "m1.xlarge", "c1.xlarge"]
     if arg_hash['instance_type']
       if !possible_instance_types.include?(arg_hash['instance_type'])
         raise BadCommandLineArgException.new(INSTANCE_FLAG_NOT_IN_SET_MSG)

--- a/lib/vm_tools.rb
+++ b/lib/vm_tools.rb
@@ -381,6 +381,17 @@ module VMTools
       "min_images" => "#{node_layout.min_images}",
       "max_images" => "#{node_layout.max_images}"
     }
+
+    EC2_ENVIRONMENT_VARIABLES.each { |var|
+      cloud_creds["CLOUD1_#{var}"] = ENV[var]
+    }
+
+    if cloud_creds["infrastructure"] == "euca"
+      ["EC2_URL", "S3_URL"].each { |var|
+        cloud_creds["CLOUD1_#{var}"] = ENV[var]
+      }
+    end
+
     cloud_creds.merge!(VMTools.get_creds_from_env)
     return cloud_creds
   end


### PR DESCRIPTION
...but not hybrid cloud), sending over credentials as CLOUD1_credential, fixing issue #18. Requires corresponding iaas-fix branch from appscale/iaas-fix.

Tested on EC2 but not yet on Eucalyptus (as our test cloud reports `RunInstancesType: Failed to allocate network tag for network: arn:aws:euca:eucalyptus:759276108939:security-group/appscalecgb14/: no network tags are free` when we try to spawn instances).
