### PR TITLE
Verifying that ami/emi user provides actually exists

### DIFF
--- a/lib/common_functions.rb
+++ b/lib/common_functions.rb
@@ -1205,6 +1205,7 @@ module CommonFunctions
 
     if infrastructure && infrastructure != "hybrid"
       VMTools.verify_credentials_are_set_correctly(infrastructure)
+      VMTools.validate_machine_image(machine, infrastructure)
     end
 
     # If the user hasn't given us an ips.yaml file, then they're running in a cloud

--- a/test/tc_vm_tools.rb
+++ b/test/tc_vm_tools.rb
@@ -1,10 +1,55 @@
 $:.unshift File.join(File.dirname(__FILE__), "..", "lib")
 require 'vm_tools'
 
-require 'test/unit'
+
+require 'flexmock/test_unit'
 
 
 class TestVMTools < Test::Unit::TestCase
-  def test_nothing
+
+
+  def setup
+    # mock out anything potentially harmful to our filesystem
+    flexmock(CommonFunctions).should_receive(:shell).with("").
+      and_return()
   end
+
+
+  def test_ami_validation_when_in_bad_format
+    # if the user wants to run appscale and gives us a machine
+    # image that isn't either a euca or ec2 image, we should
+    # throw an exception
+    assert_raises(InfrastructureException) {
+      VMTools.validate_machine_image("blarg", "boocloud")
+    }
+  end
+
+
+  def test_ami_validation_when_ami_does_not_exist
+    # if the user wants us to run appscale on an ami that doesn't
+    # exist, we should throw an exception
+
+    flexmock(CommonFunctions).should_receive(:shell).
+      with("boocloud-describe-images ami-image 2>&1").and_return()
+
+    assert_raises(InfrastructureException) {
+      VMTools.validate_machine_image("ami-image", "boocloud")
+    }
+  end
+
+  
+  def test_ami_validation_when_emi_does_exist
+    # if the user wants us to run appscale on an emi that does
+    # exist, that should be fine
+
+    info = "IMAGE\temi-image"
+    flexmock(CommonFunctions).should_receive(:shell).
+      with("boocloud-describe-images emi-image 2>&1").and_return(info)
+
+    assert_nothing_raised(InfrastructureException) {
+      VMTools.validate_machine_image("emi-image", "boocloud")
+    }
+  end
+
+
 end


### PR DESCRIPTION
Fixes issue #33. Tested by giving a bad ami for EC2, and added unit tests to test failure and success scenarios.
