### PR TITLE
Updating locations metadata file after arg validation

### DIFF
--- a/lib/appscale_tools.rb
+++ b/lib/appscale_tools.rb
@@ -232,11 +232,11 @@ module AppScaleTools
 
 
   def self.remove_app(options)
-    CommonFunctions.update_locations_file(options['keyname'])
     if options['appname'].nil?
       raise BadConfigurationException.new(NO_APPNAME_GIVEN)
     end
 
+    CommonFunctions.update_locations_file(options['keyname'])
     result = CommonFunctions.confirm_app_removal(options['confirm'],
       options['appname'])
     if result == "NO"


### PR DESCRIPTION
This is for `appscale-remove-app` only, and fixes a broken test case that didn't have metadata updating mocked out.
