### PR TITLE
Enable use of m1.medium instance type on EC2

### DIFF
--- a/lib/parse_args.rb
+++ b/lib/parse_args.rb
@@ -25,9 +25,10 @@ YAML_CONTROL_MSG = "The provided IP yaml file did not have one IP " +
 EC2_USAGE_MSG = "You did not provide an ips.yaml file, and you" +
   " did not provide a machine id."
 EC2_IPS_MISSING_MSG = "You did not provide an ips.yaml or it was empty."
-INSTANCE_FLAG_NOT_IN_SET_MSG = "The instance type you provided was not " + 
-  "one of the allowed values. Currently we allow m1.large, m1.xlarge, " +
-  "and c1.xlarge as the instance types."
+POSSIBLE_INSTANCE_TYPES = ["m1.small", "m1.medium", "m1.large", "m1.xlarge", "c1.xlarge"]
+INSTANCE_FLAG_NOT_IN_SET_MSG = "The instance type you provided was " +
+  "not one of the allowed values. Currently we allow the " +
+  "#{POSSIBLE_INSTANCE_TYPES.join(', ')} instance types."
 INFRASTRUCTURE_FLAG_NOT_IN_SET_MSG = "The infrastructure you provided " + 
   "was not one of the allowed values. Currently we allow ec2 and euca " + 
   "as the infrastructure types."
@@ -278,9 +279,8 @@ module ParseArgs
       val_hash['machine'] = ENV['APPSCALE_MACHINE']
     end 
 
-    possible_instance_types = ["m1.small", "m1.large", "m1.xlarge", "c1.xlarge"]
     if arg_hash['instance_type']
-      if !possible_instance_types.include?(arg_hash['instance_type'])
+      if !POSSIBLE_INSTANCE_TYPES.include?(arg_hash['instance_type'])
         raise BadCommandLineArgException.new(INSTANCE_FLAG_NOT_IN_SET_MSG)
       end
       val_hash['instance_type'] = arg_hash['instance_type']

--- a/test/tc_parse_args.rb
+++ b/test/tc_parse_args.rb
@@ -185,4 +185,21 @@ class TestParseArgs < Test::Unit::TestCase
     }
   end
 
+  def test_instance_types
+    # Specifying m1.large as the instance type is acceptable.
+    args_1 = ['--instance_type', 'm1.large']
+    all_flags_1 = ['instance_type']
+    assert_nothing_raised(BadCommandLineArgException) {
+      ParseArgs.get_vals_from_args(args_1, all_flags_1, @usage)
+    }
+
+    # Specifying blarg1.humongous as the instance type is not
+    # acceptable.
+    args_2 = ['--instance_type', 'blarg1.humongous']
+    all_flags_2 = ['instance_type']
+    assert_raises(BadCommandLineArgException) {
+      ParseArgs.get_vals_from_args(args_2, all_flags_2, @usage)
+    }
+  end
+
 end


### PR DESCRIPTION
Refactored parse_args.rb to enable m1.medium to be used for EC2 deployments, and added test cases to perform validation of the `--instance_type` flag on `appscale-run-instances`.

Contains merges from `shatterednirvana/warn-on-unsupported`, so I'd recommend to delay code reviews on this pull request until the other branch is merged in.
