### PR TITLE
Changed exception type thrown when starting AppController

### DIFF
--- a/lib/common_functions.rb
+++ b/lib/common_functions.rb
@@ -1409,7 +1409,7 @@ module CommonFunctions
     Kernel.sleep(1)
 
     begin
-      Timeout::timeout(60) {
+      Timeout::timeout(60, AppScaleException) {
         GodInterface.start(:controller, start, stop, 
           AppScaleTools::DJINN_SERVER_PORT,
           {'APPSCALE_HOME' => remote_home}, ip, ssh_key)
@@ -1420,7 +1420,7 @@ module CommonFunctions
         CommonFunctions.sleep_until_port_is_open(ip, 
           AppScaleTools::DJINN_SERVER_PORT, AppScaleTools::USE_SSL)
       }
-    rescue Timeout::Error
+    rescue AppScaleException
       retry
     end
   end


### PR DESCRIPTION
Now is AppScaleException, to differentiate it from Timeout::Error, which can be thrown when we wait for ports to open (fixing issue #45).
