### PR TITLE
Added more descriptive error message 

### DIFF
--- a/lib/vm_tools.rb
+++ b/lib/vm_tools.rb
@@ -283,6 +283,8 @@ module VMTools
         Kernel.puts("Need to retry with addressing private. Will try " +
           "again in a moment.")
         command_to_run << " --addressing private"
+      elsif run_instances =~ /(PROBLEM)|(RunInstancesType: Failed to allocate network tag)/
+        raise InfrastructureException.new("No network tags are currently free in your Eucalyptus deployment. Please delete some security groups and try again.")
       elsif run_instances =~ /(PROBLEM)|(RunInstancesType: Failed)/
         raise InfrastructureException.new("Saw the following error " +
           "message from iaas tools. Please resolve the issue and try " +


### PR DESCRIPTION
Changed message when running in Euca when no network tags are free to say exactly what to do in that scenario (that is, delete some security groups and try again).
