### PR TITLE
Parse app.yaml correctly for Python 2.7 apps

### DIFF
--- a/lib/common_functions.rb
+++ b/lib/common_functions.rb
@@ -51,7 +51,7 @@ CLOUDY_CREDS = ["ec2_access_key", "ec2_secret_key",
   "CLOUD1_EC2_ACCESS_KEY", "CLOUD1_EC2_SECRET_KEY"]
 
 
-VER_NUM = "1.6.3"
+VER_NUM = "1.6.5"
 AS_VERSION = "AppScale Tools, Version #{VER_NUM}, http://appscale.cs.ucsb.edu"
 
 


### PR DESCRIPTION
Alters the tools so that they know that `python27` as a `runtime` means that the app is Python 2.7, and passes this information along to the AppController and UserAppServer.
