### PR TITLE
Changing the build to install latest Euca2ools and Boto

### DIFF
--- a/debian/appscale_build.sh
+++ b/debian/appscale_build.sh
@@ -13,9 +13,11 @@ echo "Ubuntu ${DIST}"
 
 # install runtime dependency
 # for distro
+EUCA_TOOLS_VERSION="2.1"
 PACKAGES=`find debian -regex ".*\/control\.${DIST}\$" -exec mawk -f debian/package-list.awk {} +`
+add-apt-repository "deb http://downloads.eucalyptus.com/software/euca2ools/${EUCA_TOOLS_VERSION}/ubuntu/ ${DIST} main"
 apt-get update
-apt-get install -y ${PACKAGES}
+apt-get install -y --force-yes ${PACKAGES}
 if [ $? -ne 0 ]; then
     echo "Fail to install depending packages for runtime."
     exit 1

--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -99,6 +99,7 @@ EOF
     cp /usr/local/ec2-api-tools/bin/* ${DESTDIR}/usr/local/bin 
     cp /usr/local/ec2-ami-tools/bin/* ${DESTDIR}/usr/local/bin 
  fi
+ easy_install boto==2.6
 }
 
 installeuca2ools()

--- a/debian/appscale_install_lucid.sh
+++ b/debian/appscale_install_lucid.sh
@@ -13,6 +13,7 @@ case "$1" in
 	# scratch install of appscale including post script.
 	installappscaletools
 	postinstallappscaletools
+    installsetuptools
     installec2ools
 	keygen
 	;;


### PR DESCRIPTION
Change required to use Boto in the infra manager. Installs Boto 2.6 and Euca2ools 2.1.
