### PR TITLE
Obscure EC2 creds

### DIFF
--- a/lib/common_functions.rb
+++ b/lib/common_functions.rb
@@ -48,7 +48,7 @@ IP_OR_FQDN = /#{IP_REGEX}|#{FQDN_REGEX}/
 CLOUDY_CREDS = ["ec2_access_key", "ec2_secret_key", 
   "aws_access_key_id", "aws_secret_access_key", 
   "SIMPLEDB_ACCESS_KEY", "SIMPLEDB_SECRET_KEY",
-  "CLOUD1_EC2_ACCESS_KEY", "CLOUD1_EC2_SECRET_KEY"]
+  "CLOUD_EC2_ACCESS_KEY", "CLOUD_EC2_SECRET_KEY"]
 
 
 VER_NUM = "1.6.5"

--- a/test/tc_common_functions.rb
+++ b/test/tc_common_functions.rb
@@ -138,24 +138,24 @@ class TestCommonFunctions < Test::Unit::TestCase
     creds = {
       'ec2_access_key' => 'ABCDEFG',
       'ec2_secret_key' => 'HIJKLMN',
-      'CLOUD1_EC2_ACCESS_KEY' => 'OPQRSTU',
-      'CLOUD1_EC2_SECRET_KEY' => 'VWXYZAB'
+      'CLOUD_EC2_ACCESS_KEY' => 'OPQRSTU',
+      'CLOUD_EC2_SECRET_KEY' => 'VWXYZAB'
     }
 
     expected = {
       'ec2_access_key' => '***DEFG',
       'ec2_secret_key' => '***KLMN',
-      'CLOUD1_EC2_ACCESS_KEY' => '***RSTU',
-      'CLOUD1_EC2_SECRET_KEY' => '***YZAB'
+      'CLOUD_EC2_ACCESS_KEY' => '***RSTU',
+      'CLOUD_EC2_SECRET_KEY' => '***YZAB'
     }
 
     actual = CommonFunctions.obscure_creds(creds)
     assert_equal(expected['ec2_access_key'], actual['ec2_access_key'])
     assert_equal(expected['ec2_secret_key'], actual['ec2_secret_key'])
-    assert_equal(expected['CLOUD1_EC2_ACCESS_KEY'],
-      actual['CLOUD1_EC2_ACCESS_KEY'])
-    assert_equal(expected['CLOUD1_EC2_SECRET_KEY'],
-      actual['CLOUD1_EC2_SECRET_KEY'])
+    assert_equal(expected['CLOUD_EC2_ACCESS_KEY'],
+      actual['CLOUD_EC2_ACCESS_KEY'])
+    assert_equal(expected['CLOUD_EC2_SECRET_KEY'],
+      actual['CLOUD_EC2_SECRET_KEY'])
   end
 
 


### PR DESCRIPTION
The introduction of the Python InfrastructureManager caused the EC2 cloud variables `CLOUD1_EC2_ACCESS_KEY` and `CLOUD1_EC2_SECRET_KEY` to be renamed to `CLOUD_EC2_ACCESS_KEY` and `CLOUD_EC2_SECRET_KEY`. Therefore, this causes credentials to be printed to stdout (as the tools' obscure_creds function wasn't changed to match this change). This pull fixes that oversight.
