### PR TITLE
Printing out version of AppScale used when starting up

### DIFF
--- a/lib/common_functions.rb
+++ b/lib/common_functions.rb
@@ -1339,7 +1339,7 @@ module CommonFunctions
       deployment = "non-cloud environment"
     end
 
-    Kernel.puts "About to start AppScale over a #{deployment}."
+    Kernel.puts "About to start AppScale #{VER_NUM} over a #{deployment}."
   end
 
   def self.generate_node_layout(options)


### PR DESCRIPTION
When the user invokes `appscale-run-instances`, we now print out what version of AppScale they are running with. This helps us debug which version of AppScale the user is running without having to explicitly ask them.
