### PR TITLE
Added "appscale down" command

### DIFF
--- a/bin/appscale
+++ b/bin/appscale
@@ -59,7 +59,7 @@ elif command == "deploy":
   except AppScalefileException as e:
     cprint(e, 'red')
     exit(1)
-elif command == "destroy":
+elif command == "destroy" or command == "down":
   try:
     appscale.destroy()
   except AppScalefileException as e:

--- a/lib/appscale.py
+++ b/lib/appscale.py
@@ -56,6 +56,7 @@ Available commands:
   status: Reports on the state of a currently running AppScale deployment.
   deploy: Deploys a Google App Engine app to AppScale.
   destroy: Terminates the currently running AppScale deployment.
+  down: An alias for 'destroy'.
   help: Displays this message.
 """
 


### PR DESCRIPTION
Since starting AppScale is done via `up`, it makes sense to have a symmetric alias for shutting down AppScale. This pull request adds `down` to alias to `destroy`, fixing this issue.
