### PR TITLE
Erasing binary that sometimes shows up in locations.yaml

### DIFF
--- a/lib/common_functions.rb
+++ b/lib/common_functions.rb
@@ -914,7 +914,7 @@ module CommonFunctions
   #     data in it.
   def self.erase_binary_in_yaml(path)
     contents = self.read_file(path, chomp=false)
-    new_contents = contents.gsub(/(.*)---/, '---')
+    new_contents = contents.gsub(/(.*)---?/, '---')
     self.write_file(path, new_contents)
   end
 


### PR DESCRIPTION
`YAML.dump` in `lib/common_functions.rb` was writing binary to the beginning of our YAML files, causing future attempts to read it to fail. Fixes issue #89 by removing that binary off the beginning of the file, but because we don't know why this was happening, opened issue #90 to investigate at a later time.
