### PR TITLE
Not crashing on 'appscale up' if invalid key is found

### DIFF
--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -117,7 +117,6 @@ installpylibs()
   easy_install termcolor
   easy_install M2Crypto
   easy_install SOAPpy
-  easy_install paramiko
   easy_install pyyaml
   easy_install boto==2.6
   easy_install argparse


### PR DESCRIPTION
Prior to this pull, running on EC2 with a certain keyname would put an SSH key in ~/.appscale that paramiko couldn't read (causing it to throw an exception). This pull addresses that problem by using RemoteHelper.ssh instead of paramiko to see if ssh keys work. Since we don't use paramiko anymore I also removed it from the build script.
