### PR TITLE
Removed verbose=True from appscalefile templates

### DIFF
--- a/templates/AppScalefile-cloud
+++ b/templates/AppScalefile-cloud
@@ -27,9 +27,9 @@ keyname : 'appscalekey'
 group : 'appscalegroup'
 
 # Whether or not increased output should be presented to standard output.
-# We recommend setting this to True in all cases, as it produces much
-# more useful logging information.
-verbose : True
+# We recommend setting this to True if you are encountering issues with
+# AppScale and wish to see precisely where they are coming from.
+#verbose : True
 
 # The minimum number of machines that should be used for your AppScale
 # deployment.

--- a/templates/AppScalefile-cluster
+++ b/templates/AppScalefile-cluster
@@ -38,9 +38,9 @@ ips_layout :
 table : 'cassandra'
 
 # Whether or not increased output should be presented to standard output.
-# We recommend setting this to True in all cases, as it produces much
-# more useful logging information.
-verbose : True
+# We recommend setting this to True if you are encountering issues with
+# AppScale and wish to see precisely where they are coming from.
+#verbose : True
 
 # The number of copies (replicas) of each piece of data stored in the
 # specified database. By default, we determine the optimal value based


### PR DESCRIPTION
The default level of output is now sufficient, and the amount of output produced in the verbose mode is far too verbose for the average user.
