### PR TITLE
Printing more useful info on describe-instances

### DIFF
--- a/lib/appscale_tools.py
+++ b/lib/appscale_tools.py
@@ -160,7 +160,7 @@ class AppScaleTools():
       try:
         AppScaleLogger.log(acc.get_status())
       except Exception as e:
-        AppScaleLogger.warn("Unable to contact machine: " + str(e))
+        AppScaleLogger.warn("Unable to contact machine: {0}\n".format(str(e)))
 
     AppScaleLogger.success("View status information about your AppScale " + \
       "deployment at http://{0}/status".format(login_host))


### PR DESCRIPTION
Catching exceptions if getting status fails, and printing each host that we're printing the status for.
