### PR TITLE
Changed replication flag to have better name

### DIFF
--- a/lib/parse_args.py
+++ b/lib/parse_args.py
@@ -156,7 +156,7 @@ class ParseArgs():
         default=self.DEFAULT_DATASTORE,
         choices=self.ALLOWED_DATASTORES,
         help="the datastore to use")
-      self.parser.add_argument('-n', type=int,
+      self.parser.add_argument('--replication', '-n', type=int,
         help="the database replication factor")
 
       # flags relating to application servers
@@ -387,7 +387,7 @@ class ParseArgs():
       BadConfigurationException: If the values for any of the
         database flags are not valid.
     """
-    if self.args.n is not None and self.args.n < 1:
+    if self.args.replication is not None and self.args.replication < 1:
       raise BadConfigurationException("Replication factor must exceed 0.")
 
 

--- a/test/test_appscale_logger.py
+++ b/test/test_appscale_logger.py
@@ -65,7 +65,7 @@ class TestAppScaleLogger(unittest.TestCase):
       "ips" : None,
       "ips_layout" : None,
       "keyname" : "appscale",
-      "n" : None,
+      "replication" : None,
       "scp" : None,
       "table" : "cassandra",
       "test" : False,

--- a/test/test_parse_args.py
+++ b/test/test_parse_args.py
@@ -128,7 +128,7 @@ class TestParseArgs(unittest.TestCase):
     # Specifying a positive integer for n should be ok
     argv_5 = self.cloud_argv[:] + ['--table', 'cassandra', '-n', '2']
     actual_5 = ParseArgs(argv_5, self.function)
-    self.assertEquals(2, actual_5.args.n)
+    self.assertEquals(2, actual_5.args.replication)
 
 
   def test_gather_logs_flags(self):


### PR DESCRIPTION
Previously the replication flag was set only as `-n`, and NodeLayout was looking for `replication`. This mismatch caused NodeLayout to always ignore what the user set for replication. This pull request fixes that problem by adding `--replication` as the long version for `-n`, and fixes unit tests accordingly.
