### PR TITLE
Altered how we see if images exist in Eucalyptus

### DIFF
--- a/lib/agents/euca_agent.py
+++ b/lib/agents/euca_agent.py
@@ -117,3 +117,25 @@ class EucalyptusAgent(EC2Agent):
         cidr_ip='0.0.0.0/0')
 
     return True
+
+
+  def does_image_exist(self, parameters):
+    """
+    Queries Eucalyptus to see if the specified image exists.
+
+    Args:
+      parameters A dict that contains the machine ID to check for existence.
+    Returns:
+      True if the machine ID exists, False otherwise.
+    """
+    # note that we can't use does_image_exist in EC2Agent. There, if the image
+    # doesn't exist, it throws an EC2ResponseError, but in Eucalyptus, it
+    # doesn't (and returns None instead).
+    conn = self.open_connection(parameters)
+    image_id = parameters[self.PARAM_IMAGE_ID]
+    if conn.get_image(image_id):
+      AppScaleLogger.log('Machine image {0} does exist'.format(image_id))
+      return True
+    else:
+      AppScaleLogger.log('Machine image {0} does not exist'.format(image_id))
+      return False

--- a/test/test_parse_args.py
+++ b/test/test_parse_args.py
@@ -54,7 +54,7 @@ class TestParseArgs(unittest.TestCase):
     fake_ec2.should_receive('get_image').with_args('ami-ABCDEFG') \
       .and_return()
     fake_ec2.should_receive('get_image').with_args('emi-ABCDEFG') \
-      .and_return()
+      .and_return('anything')
 
     flexmock(boto)
     boto.should_receive('connect_ec2').with_args('baz', 'baz').and_return(fake_ec2)


### PR DESCRIPTION
This is due to a euca bug (https://eucalyptus.atlassian.net/browse/EUCA-4963), where it returns `None` if we try a `get_image` on non-existent image (instead of raising an `EC2ResponseError`).
