### PR TITLE
Failing if secret key file is found instead of locations.yaml

### DIFF
--- a/lib/local_state.py
+++ b/lib/local_state.py
@@ -73,12 +73,12 @@ class LocalState():
 
   @classmethod
   def ensure_appscale_isnt_running(cls, keyname, force):
-    """Checks the locations.yaml file to see if AppScale is running, and
+    """Checks the secret key file to see if AppScale is running, and
     aborts if it is.
 
     Args:
       keyname: The keypair name that is used to identify AppScale deployments.
-      force: A bool that is used to run AppScale even if the locations file
+      force: A bool that is used to run AppScale even if the secret key file
         is present.
     Raises:
       BadConfigurationException: If AppScale is already running.
@@ -86,7 +86,7 @@ class LocalState():
     if force:
       return
 
-    if os.path.exists(cls.get_locations_yaml_location(keyname)):
+    if os.path.exists(cls.get_secret_key_location(keyname)):
       raise BadConfigurationException("AppScale is already running. Terminate" +
         " it or use the --force flag to run anyways.")
 

--- a/test/test_local_state.py
+++ b/test/test_local_state.py
@@ -56,8 +56,8 @@ class TestLocalState(unittest.TestCase):
   def test_ensure_appscale_isnt_running_but_it_is(self):
     # if there is a locations.yaml file and force isn't set,
     # we should abort
-    os.path.should_receive('exists').with_args(self.locations_yaml) \
-      .and_return(True)
+    os.path.should_receive('exists').with_args(
+      LocalState.get_secret_key_location(self.keyname)).and_return(True)
 
     self.assertRaises(BadConfigurationException,
       LocalState.ensure_appscale_isnt_running, self.keyname,


### PR DESCRIPTION
Since it is written much earlier in the deployment process, the secret key file is a better file to check existence on than locations.yaml. If we use locations.yaml, we have a race condition that exists where a user can run two AppScale deployments with the same keyname, where the later one immediately fails, but writes its own secret key (later messing up the first deployment).
