### PR TITLE
Removed m2crypto import

### DIFF
--- a/lib/local_state.py
+++ b/lib/local_state.py
@@ -17,10 +17,6 @@ import uuid
 import yaml
 
 
-# Third-party imports
-import M2Crypto
-
-
 # AppScale-specific imports
 from appcontroller_client import AppControllerClient
 from appscale_logger import AppScaleLogger


### PR DESCRIPTION
A previous pull request removed M2Crypto from the appscale tools, but forgot to remove this import statement. This pull request remedies that problem.
