### PR TITLE
Not injecting flag for run-instances if the value was set to False

### DIFF
--- a/lib/appscale.py
+++ b/lib/appscale.py
@@ -221,6 +221,8 @@ Available commands:
 
       if value is True:
         command.append(str("--%s" % key))
+      elif value is False:
+        pass
       else:
         if key == "ips_layout":
           command.append("--ips_layout")


### PR DESCRIPTION
This is consistent with what we do for terminate-instances.
