### PR TITLE
installing httplib2, used by the GCE support, and installing all needed ...

### DIFF
--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -76,6 +76,7 @@ installpylibs()
   easy_install boto==2.6
   easy_install oauth2client
   easy_install google-api-python-client
+  easy_install httplib2
   easy_install argparse
 }
 

--- a/osx/appscale_install.sh
+++ b/osx/appscale_install.sh
@@ -8,7 +8,7 @@ mkdir -p $TARGETDIR
 cp -r bin lib templates LICENSE README.md $TARGETDIR || exit 1
 
 # from installpylibs
-easy_install termcolor M2Crypto SOAPpy pyyaml boto==2.6 argparse
+easy_install termcolor M2Crypto SOAPpy pyyaml boto==2.6 argparse oauth2client google-api-python-client httplib2
 
 # create ssh private key if it does not exist
 test -e ~/.ssh/id_rsa || ssh-keygen -q -t rsa -f ~/.ssh/id_rsa -N ""


### PR DESCRIPTION
...libraries for GCE on OS X
