### PR TITLE
Raising UnknownInfrastructureException instead of NameError

### DIFF
--- a/lib/agents/factory.py
+++ b/lib/agents/factory.py
@@ -1,23 +1,31 @@
 from agents.ec2_agent import EC2Agent
 from agents.euca_agent import EucalyptusAgent
 from agents.gce_agent import GCEAgent
+from custom_exceptions import UnknownInfrastructureException
+
 
 __author__ = 'hiranya'
 __email__ = 'hiranya@appscale.com'
 
+
 class InfrastructureAgentFactory:
-  """
-  Factory implementation which can be used to instantiate concrete infrastructure
-  agents.
-  """
+  """ Factory implementation which can be used to instantiate infrastructure
+  agents. """
 
-  VALID_AGENTS = ['ec2', 'euca', 'gce']
 
+  # A set containing each of the cloud infrastructures that AppScale can
+  # deploy over.
+  VALID_AGENTS = ('ec2', 'euca', 'gce')
+
+
+  # A dict that maps each VALID_AGENT above to the class that implements
+  # support for it in AppScale.
   agents = {
     'ec2': EC2Agent,
     'euca': EucalyptusAgent,
     'gce': GCEAgent
   }
+
 
   @classmethod
   def create_agent(cls, infrastructure):
@@ -25,17 +33,16 @@ class InfrastructureAgentFactory:
     Instantiate a new infrastructure agent.
 
     Args:
-      infrastructure  A string indicating the type of infrastructure
-                      agent to be initialized.
-
+      infrastructure: A string indicating the type of infrastructure
+        agent to be initialized.
     Returns:
       An infrastructure agent instance that implements the BaseAgent API
-
     Raises:
-      NameError       If the given input string does not map to any known
-                      agent type.
+      UnknownInfrastructureException: If the infrastructure given is not one
+        that we support.
     """
     if cls.agents.has_key(infrastructure):
       return cls.agents[infrastructure]()
     else:
-      raise NameError('Unrecognized infrastructure: ' + str(infrastructure))
+      raise UnknownInfrastructureException('Unrecognized infrastructure: {0}' \
+        .format(infrastructure))

--- a/lib/custom_exceptions.py
+++ b/lib/custom_exceptions.py
@@ -57,6 +57,13 @@ class TimeoutException(Exception):
   pass
 
 
+class UnknownInfrastructureException(Exception):
+  """ A special Exception class that should be thrown if a user is attempting to
+  utilize a cloud infrastructure that the AppScale Tools do not support.
+  """
+  pass
+
+
 class UsageException(Exception):
   """A special Exception class that should be thrown if the user attempts
   to run the 'help' directive, which reports on the usage of this tool.

--- a/test/test_factory.py
+++ b/test/test_factory.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# Programmer: Chris Bunch (chris@appscale.com)
+
+
+# General-purpose Python library imports
+import os
+import sys
+import unittest
+
+# Third party testing libraries
+from flexmock import flexmock
+
+
+# AppScale import, the library that we're testing here
+lib = os.path.dirname(__file__) + os.sep + ".." + os.sep + "lib"
+sys.path.append(lib)
+from agents.factory import InfrastructureAgentFactory
+from custom_exceptions import UnknownInfrastructureException
+
+
+class TestFactory(unittest.TestCase):
+
+
+  def test_bad_agent_name(self):
+    # Passing in an invalid agent name should raise an exception.
+    self.assertRaises(UnknownInfrastructureException,
+      InfrastructureAgentFactory.create_agent, 'bad agent name')

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -20,6 +20,7 @@ from test_appscale_terminate_instances import TestAppScaleTerminateInstances
 
 # imports for appscale library tests
 from test_appscale_logger import TestAppScaleLogger
+from test_factory import TestFactory
 from test_local_state import TestLocalState
 from test_node_layout import TestNodeLayout
 from test_parse_args import TestParseArgs
@@ -31,7 +32,7 @@ test_cases = [TestAppScale, TestAppScaleAddInstances, TestAppScaleAddKeypair,
   TestAppScaleDescribeInstances, TestAppScaleGatherLogs, TestAppScaleRemoveApp,
   TestAppScaleResetPassword, TestAppScaleRunInstances,
   TestAppScaleTerminateInstances, TestAppScaleUploadApp, TestAppScaleLogger,
-  TestLocalState, TestNodeLayout, TestParseArgs, TestRemoteHelper,
+  TestFactory, TestLocalState, TestNodeLayout, TestParseArgs, TestRemoteHelper,
   TestVersionHelper]
 
 test_case_names = []


### PR DESCRIPTION
Enables unittest to catch it in tests
