### PR TITLE
Better exception handling for 'appscale-gather-logs'

### DIFF
--- a/lib/appscale_tools.py
+++ b/lib/appscale_tools.py
@@ -8,6 +8,7 @@ import json
 import os
 import re
 import shutil
+import socket
 import sys
 import time
 import uuid
@@ -191,11 +192,19 @@ class AppScaleTools():
     acc = AppControllerClient(LocalState.get_login_host(options.keyname),
       LocalState.get_secret_key(options.keyname))
 
+    try:
+      all_ips = acc.get_all_public_ips()
+    except socket.error:  # Occurs when the AppController has failed.
+      AppScaleLogger.warn("Couldn't get an up-to-date listing of the " + \
+        "machines in this AppScale deployment. Using our locally cached " + \
+        "info instead.")
+      all_ips = LocalState.get_all_public_ips(options.keyname)
+
     # do the mkdir after we get the secret key, so that a bad keyname will
     # cause the tool to crash and not create this directory
     os.mkdir(options.location)
 
-    for ip in acc.get_all_public_ips():
+    for ip in all_ips:
       # Get the logs from each node, and store them in our local directory
       local_dir = "{0}/{1}".format(options.location, ip)
       os.mkdir(local_dir)


### PR DESCRIPTION
Using list of nodes stored in locations.json if we can't get an up-to-date list from the AppController (e.g., if the appcontroller has failed).
