### PR TITLE
added support for unstable debian releases

### DIFF
--- a/debian/appscale_build.sh
+++ b/debian/appscale_build.sh
@@ -2,6 +2,11 @@
 
 export DIST=`lsb_release -c -s`
 
+if [ "$DIST" == "n/a" ]
+then
+  DIST="na"
+fi
+
 cd `dirname $0`/..
 
 if [ ! -e ./debian/appscale_install_${DIST}.sh ]; then

--- a/debian/appscale_install_na.sh
+++ b/debian/appscale_install_na.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+. debian/appscale_install_functions.sh
+
+DESTDIR=$2
+DIST=n/a
+
+installappscaletools
+installsetuptools
+installpylibs
+keygen
+


### PR DESCRIPTION
We use a custom build of Debian. I updated the build scripts to support this situation.
The `lsb_release -c -s` command returns the string "n/a" on this release.

Maybe this is useful for someone else and AppScale can also support this scenario.

```
$ lsb_release -a
No LSB modules are available.
Distributor ID: Debian
Description:    Debian GNU/Linux testing/unstable
Release:    testing/unstable
Codename:   n/a

```
