### PR TITLE
Make sure the 'cert' directory exists.

### DIFF
--- a/lib/remote_helper.py
+++ b/lib/remote_helper.py
@@ -593,6 +593,8 @@ class RemoteHelper():
       options.keyname), '/etc/appscale/ssh.key', options.verbose)
 
     LocalState.generate_ssl_cert(options.keyname, options.verbose)
+    cls.ssh(host, options.keyname, 'mkdir -p /etc/appscale/certs',
+      options.verbose)
     cls.scp(host, options.keyname, LocalState.get_certificate_location(
       options.keyname), '/etc/appscale/certs/mycert.pem', options.verbose)
     cls.scp(host, options.keyname, LocalState.get_private_key_location(


### PR DESCRIPTION
While working on a docker instance, I got into an error copying the certs over since the cert directory didn't exist on the target. This was tested on that docker instance.