### PR TITLE
Remove all .pyc files before tarring the app.

### DIFF
--- a/lib/appscale_tools.py
+++ b/lib/appscale_tools.py
@@ -603,10 +603,9 @@ class AppScaleTools(object):
       AppScaleLogger.log("Uploading initial version of app {0}".format(app_id))
       userappclient.reserve_app_id(username, app_id, app_language)
 
-    # Remove all .pyc files before tarring.
+    # Ignore all .pyc files while tarring.
     if app_language == 'python27':
-      LocalState.shell("cd '{0}' && find . -name \*.pyc | xargs rm".\
-        format(file_location), options.verbose)
+      AppScaleLogger.log("Ignoring .pyc files")
 
     remote_file_path = RemoteHelper.copy_app_to_host(file_location,
       options.keyname, options.verbose)

--- a/lib/remote_helper.py
+++ b/lib/remote_helper.py
@@ -970,8 +970,8 @@ class RemoteHelper(object):
     AppScaleLogger.log("Tarring application")
     rand = str(uuid.uuid4()).replace('-', '')[:8]
     local_tarred_app = "/tmp/appscale-app-{0}-{1}.tar.gz".format(app_id, rand)
-    LocalState.shell("cd '{0}' && tar -czhf {1} *".format(app_location,
-      local_tarred_app), is_verbose)
+    LocalState.shell("cd '{0}' && tar -czhf {1} --exclude='*.pyc' *".format(
+      app_location, local_tarred_app), is_verbose)
 
     AppScaleLogger.log("Copying over application")
     remote_app_tar = "{0}/{1}.tar.gz".format(cls.REMOTE_APP_DIR, app_id)


### PR DESCRIPTION
Remove .pyc files before uploading a Python app because there were known to cause unexpected behavior at runtime.
