### PR TITLE
Disable certificate verification

### DIFF
--- a/lib/appcontroller_client.py
+++ b/lib/appcontroller_client.py
@@ -69,6 +69,10 @@ class AppControllerClient():
       self.PORT))
     self.secret = secret
 
+    # Disable certificate verification for Python 2.7.9.
+    if hasattr(ssl, '_create_unverified_context'):
+      ssl._create_default_https_context = ssl._create_unverified_context
+
 
   def run_with_timeout(self, timeout_time, default, num_retries, function,
     *args):

--- a/lib/user_app_client.py
+++ b/lib/user_app_client.py
@@ -6,6 +6,7 @@
 # General-purpose Python libraries
 import re
 import time
+import ssl
 
 
 # Third-party imports
@@ -64,6 +65,10 @@ class UserAppClient():
     self.host = host
     self.server = SOAPpy.SOAPProxy('https://%s:%s' % (host, self.PORT))
     self.secret = secret
+
+    # Disable certificate verification for Python 2.7.9.
+    if hasattr(ssl, '_create_unverified_context'):
+      ssl._create_default_https_context = ssl._create_unverified_context
 
 
   def create_user(self, username, password, account_type='xmpp_user'):


### PR DESCRIPTION
This is a temporary fix that allows the tools to work with Python 2.7.9. It can be removed once the tools can verify the self-signed certificate that the AppController uses.