### PR TITLE
Don't override an init.d script.

### DIFF
--- a/lib/remote_helper.py
+++ b/lib/remote_helper.py
@@ -686,16 +686,7 @@ class RemoteHelper(object):
     cls.ssh(host, keyname, 'service monit start', is_verbose)
     time.sleep(1)
 
-    # Make the controller a service.
-    cls.ssh(host, keyname, 'cp {0} {1}'.format(
-      '/root/appscale/AppController/scripts/appcontroller',
-      '/etc/init.d/'), is_verbose)
-
-    # Init.d requires the script to be executable.
-    cls.ssh(host, keyname, 'chmod +x {0}'.format(
-      '/etc/init.d/appcontroller'), is_verbose)
-
-    # Finally, start the AppController.
+    # Start the AppController.
     cls.ssh(host, keyname, 'monit start -g controller', is_verbose)
     time.sleep(1)
 

--- a/templates/appcontroller.cfg
+++ b/templates/appcontroller.cfg
@@ -1,5 +1,5 @@
 check process controller-17443 matching "/usr/bin/ruby -w /root/appscale/AppController/djinnServer.rb"
   group controller
-  start program = "/usr/sbin/service appcontroller start"
-  stop program = "/usr/sbin/service appcontroller stop"
+  start program = "/usr/sbin/service appscale-controller start"
+  stop program = "/usr/sbin/service appscale-controller stop"
   if memory is greater than 250 MB for 5 cycles then restart


### PR DESCRIPTION
The init.d script will be put in place at install time, no need to
override it. The script will not start appscale-controller unless the
secret is been put in place (ie AppScale is configured).