### PR TITLE
Make sure the local appscale path exists

### DIFF
--- a/lib/agents/gce_agent.py
+++ b/lib/agents/gce_agent.py
@@ -496,10 +496,22 @@ class GCEAgent(BaseAgent):
 
     if args.get('client_secrets'):
       destination = LocalState.get_client_secrets_location(args['keyname'])
+
+      # Make sure the destination's parent directory exists.
+      destination_par = os.path.abspath(os.path.join(destination, os.pardir))
+      if not os.path.exists(destination_par):
+        os.makedirs(destination_par)
+
+      shutil.copy(full_credentials, destination)
     elif args.get('oauth2_storage'):
       destination = LocalState.get_oauth2_storage_location(args['keyname'])
 
-    shutil.copy(full_credentials, destination)
+      # Make sure the destination's parent directory exists.
+      destination_par = os.path.abspath(os.path.join(destination, os.pardir))
+      if not os.path.exists(destination_par):
+        os.makedirs(destination_par)
+
+      shutil.copy(full_credentials, destination)
 
     params = {
       self.PARAM_GROUP : args['group'],


### PR DESCRIPTION
It was possible to run into a situation where the shutil.copy command threw an exception because the destination's parent directory did not exist.