### PR TITLE
Use the error message returned from google

### DIFF
--- a/lib/agents/gce_agent.py
+++ b/lib/agents/gce_agent.py
@@ -7,6 +7,7 @@ interact with Google Compute Engine.
 
 # General-purpose Python library imports
 import datetime
+import json
 import os.path
 import shutil
 import time
@@ -156,7 +157,8 @@ class GCEAgent(BaseAgent):
       GCE.
 
     Raises:
-      AgentConfigurationException: If the given GCE credentials are invalid.
+      AgentConfigurationException: If an error is encountered during
+      authentication.
     """
     gce_service, credentials = self.open_connection(parameters)
     try:
@@ -167,9 +169,9 @@ class GCEAgent(BaseAgent):
       response = request.execute(http=auth_http)
       AppScaleLogger.verbose(str(response), parameters[self.PARAM_VERBOSE])
       return True
-    except errors.HttpError:
-      raise AgentConfigurationException("We couldn't validate your GCE" + \
-        "credentials. Are your credentials valid?")
+    except errors.HttpError as e:
+      error_message = json.loads(e.content)['error']['message']
+      raise AgentConfigurationException(error_message)
 
 
   def configure_instance_security(self, parameters):


### PR DESCRIPTION
The HttpError can occur for reasons other than invalid credentials (such as an invalid availability zone).