### PR TITLE
Include manifest and prove ownership of repo

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md


### PR DESCRIPTION
This is related to issue #488 on the PyPI support section. It also ensures that the readme file gets included when packaging for PyPI.