### PR TITLE
Remove table as an option

### DIFF
--- a/templates/AppScalefile-cloud
+++ b/templates/AppScalefile-cloud
@@ -23,10 +23,6 @@ gce_instance_type : 'n1-standard-1'
 zone : 'us-east-1b' # For Amazon EC2
 #zone: 'us-central1-a' # For Google Compute Engine
 
-# The database that your Google App Engine applications will be backed by.
-# Currently only supports cassandra.
-table : 'cassandra'
-
 # Whether or not the Datastore should be erased when AppScale starts up.
 # This defaults to False, to persist your data across AppScale runs.
 # Note that your data is only persisted if you are using non-ephemeral

--- a/templates/AppScalefile-cluster
+++ b/templates/AppScalefile-cluster
@@ -34,10 +34,6 @@ ips_layout :
 
 # The search API is optional, and can be added with the "search" role.
 
-# The database that your Google App Engine applications will be backed by.
-# Currently only support cassandra.
-table : 'cassandra'
-
 # Whether or not the Datastore should be erased when AppScale starts up.
 # This defaults to False, to persist your data across AppScale runs.
 # This clears the datastore, taskqueue, and search state.


### PR DESCRIPTION
We only offer Cassandra as a backend option, so don't make it configurable.