### PR TITLE
Upgrade

### DIFF
--- a/bin/appscale
+++ b/bin/appscale
@@ -103,12 +103,6 @@ elif command == "undeploy" or command == "remove":
   except Exception, e:
     LocalState.generate_crash_log(e, traceback.format_exc())
     sys.exit(1)
-elif command == "upgrade":
-  try:
-    appscale.upgrade()
-  except Exception, e:
-    LocalState.generate_crash_log(e, traceback.format_exc())
-    sys.exit(1)
 elif command == "get":
   try:
     if len(sys.argv) != 3:

--- a/bin/appscale
+++ b/bin/appscale
@@ -103,7 +103,7 @@ elif command == "undeploy" or command == "remove":
   except Exception, e:
     LocalState.generate_crash_log(e, traceback.format_exc())
     sys.exit(1)
-elif command == "upgrade"
+elif command == "upgrade":
   try:
     appscale.upgrade()
   except Exception, e:

--- a/bin/appscale
+++ b/bin/appscale
@@ -103,6 +103,12 @@ elif command == "undeploy" or command == "remove":
   except Exception, e:
     LocalState.generate_crash_log(e, traceback.format_exc())
     sys.exit(1)
+elif command == "upgrade"
+  try:
+    appscale.upgrade()
+  except Exception, e:
+    LocalState.generate_crash_log(e, traceback.format_exc())
+    sys.exit(1)
 elif command == "get":
   try:
     if len(sys.argv) != 3:

--- a/lib/appscale.py
+++ b/lib/appscale.py
@@ -62,23 +62,43 @@ class AppScale():
   USAGE = """Usage: appscale command [<args>]
 
 Available commands:
-  init: Writes a new configuration file for starting AppScale.
-  up: Starts a new AppScale instance.
-  ssh: Logs into a virtual machine in a currently running AppScale deployment.
-  status: Reports on the state of a currently running AppScale deployment.
-  deploy: Deploys a Google App Engine app to AppScale.
-  undeploy: Removes a Google App Engine app from AppScale.
-  remove: An alias for 'undeploy'.
-  get: Gets all AppController properties matching the provided regex.
-  set: Sets an AppController property to the provided value.
-  tail: Follows the output of log files in a currently running AppScale deployment.
-  logs: Collects the logs produced by an AppScale deployment.
-  relocate: Moves a hosted app to different HTTP and HTTPS ports.
-  destroy: Gracefully terminates the currently running AppScale deployment.
-  down: An alias for 'destroy'.
-  clean: Forcefully terminates all services in a cluster AppScale deployment.
-  register: Registers an AppScale deployment with the AppScale Portal.
-  help: Displays this message.
+  clean                             forcefully terminates the AppScale
+                                    deployment and delete all data. ALL
+                                    DATA WILL BE DELETED.
+  deploy <app>                      deploys a Google App Engine app to AppScale:
+                                    <app> can be a directory with the source
+                                    code or a tar.gz of the source tree.
+  destroy                           gracefully terminates the currently
+                                    running AppScale deployment.
+  down                              an alias for 'destroy'.
+  get <regex>                       gets all AppController properties matching
+                                    the provided regex: for developers only.
+  help                              displays this message.
+  init <cloud|cluster>              writes a new configuration file for
+                                    AppScale: it will use the <cloud> or
+                                    <cluster> template. Won't override
+                                    an existing configuration.
+  logs <dir>                        collects the logs produced by an AppScale
+                                    deployment into a directory <dir>: the
+                                    directory will be created.
+  register <deployment_id>          registers an AppScale deployment with the
+                                    AppScale Portal (http://hawkeye.appscale.com).
+  relocate <appid> <http> <https>   moves the application <appid> to a
+                                    different <http> and <https> ports.
+  remove                            an alias for 'undeploy'.
+  set <property> <value>            sets an AppController <property> to the
+                                    provided <value>. For developers only.
+  ssh [#]                           logs into the #th node of the current AppScale
+                                    deployment. Default is headnode (1).
+  status                            reports on the state of a currently
+                                    running AppScale deployment.
+  tail                              follows the output of log files of an
+                                    AppScale deployment.
+  up                                starts the AppScale deployments (requires
+                                    an AppScalefile).
+  undeploy <appid>                  removes <appid> from the current
+                                    deployment. DATA ASSOCIATED WITH
+                                    THE APPLICATION WILL BE LOST.
 """
 
 

--- a/lib/appscale.py
+++ b/lib/appscale.py
@@ -58,7 +58,7 @@ class AppScale():
   TERMINATE = "ruby /root/appscale/AppController/terminate.rb clean"
 
 
-  # This is the commands used to upgrade a node: we need first to get the
+  # These are the commands used to upgrade a node: we need first to get the
   # newest boostrap.sh, then invoke it.
   GET_BOOTSTRAP = "wget -q -O /tmp/bootstrap.sh http://bootstrap.appscale.com"
   UPGRADE = "sh /tmp/bootstrap.sh --tag last"
@@ -72,13 +72,13 @@ Available commands:
                                     deployment and delete all data. ALL
                                     DATA WILL BE DELETED.
   deploy <app>                      Deploys a Google App Engine app to AppScale:
-                                    <app> can be a directory with the source
+                                    <app> can be the top level directory with the
                                     code or a tar.gz of the source tree.
   destroy                           Gracefully terminates the currently
                                     running AppScale deployment.
   down                              An alias for 'destroy'.
   get <regex>                       Gets all AppController properties matching
-                                    The provided regex: for developers only.
+                                    the provided regex: for developers only.
   help                              Displays this message.
   init <cloud|cluster>              Writes a new configuration file for
                                     AppScale: it will use the <cloud> or
@@ -88,14 +88,14 @@ Available commands:
                                     deployment into a directory <dir>: the
                                     directory will be created.
   register <deployment_id>          Registers an AppScale deployment with the
-                                    AppScale Portal (http://hawkeye.appscale.com).
-  relocate <appid> <http> <https>   Moves the application <appid> to a
+                                    AppScale Portal.
+  relocate <appid> <http> <https>   Moves the application <appid> to
                                     different <http> and <https> ports.
   remove                            An alias for 'undeploy'.
   set <property> <value>            Sets an AppController <property> to the
                                     provided <value>. For developers only.
   ssh [#]                           Logs into the #th node of the current AppScale
-                                    deployment. Default is headnode (1).
+                                    deployment. Default is headnode (0).
   status                            Reports on the state of a currently
                                     running AppScale deployment.
   tail                              Follows the output of log files of an

--- a/lib/appscale.py
+++ b/lib/appscale.py
@@ -570,13 +570,20 @@ Available commands:
     LocalState.ensure_appscale_isnt_running(keyname, force)
 
     # Let's upgrade all nodes in the deployment.
+    success = True
     all_ips = self.get_all_ips(contents_as_yaml["ips_layout"])
     for ip in all_ips:
-      RemoteHelper.ssh(ip, keyname, self.GET_BOOTSTRAP, is_verbose)
-      RemoteHelper.ssh(ip, keyname, self.UPGRADE, is_verbose)
+      try
+        RemoteHelper.ssh(ip, keyname, self.GET_BOOTSTRAP, is_verbose)
+        RemoteHelper.ssh(ip, keyname, self.UPGRADE, is_verbose)
+      except ShellException:
+        AppScaleLogger.warn("Failed to upgrade {0}.\n".format(str(ip)))
+        success = False
+        continue
 
-    AppScaleLogger.success("Successfully upgraded your AppScale deployment." \
-      "You can use 'appscale up' now to bring it back up.")
+    if success == True:
+      AppScaleLogger.success("Successfully upgraded your AppScale deployment." \
+        "You can use 'appscale up' now to bring it back up.")
 
 
   def get(self, property_regex):

--- a/lib/appscale.py
+++ b/lib/appscale.py
@@ -58,8 +58,10 @@ class AppScale():
   TERMINATE = "ruby /root/appscale/AppController/terminate.rb clean"
 
 
-  # This is the command used to upgrade a node.
-  UPGRADE = "sh /root/appscale/bootstrap.sh --git last"
+  # This is the commands used to upgrade a node: we need first to get the
+  # newest boostrap.sh, then invoke it.
+  GET_BOOTSTRAP = "wget -q -O /tmp/bootstrap.sh http://bootstrap.appscale.com"
+  UPGRADE = "sh /tmp/bootstrap.sh --tag last"
 
   # The usage that should be displayed to users if they call 'appscale'
   # with a bad directive or ask for help.
@@ -570,6 +572,7 @@ Available commands:
     # Let's upgrade all nodes in the deployment.
     all_ips = self.get_all_ips(contents_as_yaml["ips_layout"])
     for ip in all_ips:
+      RemoteHelper.ssh(ip, keyname, self.GET_BOOTSTRAP, is_verbose)
       RemoteHelper.ssh(ip, keyname, self.UPGRADE, is_verbose)
 
     AppScaleLogger.success("Successfully upgraded your AppScale deployment." \

--- a/lib/appscale.py
+++ b/lib/appscale.py
@@ -573,11 +573,12 @@ Available commands:
     success = True
     all_ips = self.get_all_ips(contents_as_yaml["ips_layout"])
     for ip in all_ips:
-      try
+      try:
         RemoteHelper.ssh(ip, keyname, self.GET_BOOTSTRAP, is_verbose)
         RemoteHelper.ssh(ip, keyname, self.UPGRADE, is_verbose)
-      except ShellException:
+      except ShellException, se:
         AppScaleLogger.warn("Failed to upgrade {0}.\n".format(str(ip)))
+        LocalState.generate_crash_log(se, traceback.format_exc())
         success = False
         continue
 


### PR DESCRIPTION
This is to provide an 'upgrade' command to appscale. The command ensure that appscale is not running, then upgrade all the nodes to the latest release. This is not working in a cloud environment.