### PR TITLE
Update oauth2client call

### DIFF
--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -48,7 +48,6 @@ installpylibs()
   pip_wrapper oauth2client
   pip_wrapper google-api-python-client
   pip_wrapper argparse
-  pip_wrapper python-gflags
 }
 
 installappscaletools()

--- a/lib/agents/gce_agent.py
+++ b/lib/agents/gce_agent.py
@@ -6,6 +6,7 @@ interact with Google Compute Engine.
 """
 
 # General-purpose Python library imports
+import argparse
 import datetime
 import json
 import os.path
@@ -1087,7 +1088,8 @@ class GCEAgent(BaseAgent):
     credentials = storage.get()
 
     if credentials is None or credentials.invalid:
-      credentials = oauth2client.tools.run(flow, storage)
+      flags = oauth2client.tools.argparser.parse_args(args=[])
+      credentials = oauth2client.tools.run_flow(flow, storage, flags)
 
     # Build the service
     return discovery.build('compute', self.API_VERSION), credentials

--- a/osx/appscale_install.sh
+++ b/osx/appscale_install.sh
@@ -8,7 +8,7 @@ mkdir -p $TARGETDIR
 cp -r bin lib templates LICENSE README.md $TARGETDIR || exit 1
 
 # from installpylibs
-easy_install termcolor SOAPpy pyyaml boto argparse oauth2client google-api-python-client httplib2 python-gflags
+easy_install termcolor SOAPpy pyyaml boto argparse oauth2client google-api-python-client httplib2
 
 # create ssh private key if it does not exist
 test -e ~/.ssh/id_rsa || ssh-keygen -q -t rsa -f ~/.ssh/id_rsa -N ""

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,7 @@ setup(
     'PyYAML',
     'boto',
     'google-api-python-client',
-    'argparse',
-    'python-gflags'
+    'argparse'
   ],
   classifiers=[
     'Development Status :: 5 - Production/Stable',

--- a/test/test_appscale_terminate_instances.py
+++ b/test/test_appscale_terminate_instances.py
@@ -372,14 +372,16 @@ class TestAppScaleTerminateInstances(unittest.TestCase):
     fake_storage = flexmock(name='fake_storage')
     fake_storage.should_receive('get').and_return(None)
 
+    fake_flags = oauth2client.tools.argparser.parse_args(args=[])
+
     flexmock(oauth2client.file)
     oauth2client.file.should_receive('Storage').with_args(str).and_return(
       fake_storage)
 
     fake_credentials = flexmock(name='fake_credentials')
     flexmock(oauth2client.tools)
-    oauth2client.tools.should_receive('run').with_args(fake_flow,
-      fake_storage).and_return(fake_credentials)
+    oauth2client.tools.should_receive('run_flow').with_args(fake_flow,
+      fake_storage, fake_flags).and_return(fake_credentials)
 
     # next, mock out http calls to GCE
     fake_http = flexmock(name='fake_http')


### PR DESCRIPTION
oauth2client.tools.run has been deprecated for over 2 years, and it was removed in the last release:

https://github.com/google/oauth2client/pull/285