### PR TITLE
Don't try to get the locale when generating a crashlog

### DIFF
--- a/appscale/tools/local_state.py
+++ b/appscale/tools/local_state.py
@@ -6,7 +6,6 @@
 import getpass
 import hashlib
 import json
-import locale
 import os
 import platform
 import re
@@ -936,17 +935,10 @@ class LocalState(object):
     crash_log_filename = '{0}log-{1}'.format(
       LocalState.LOCAL_APPSCALE_PATH, uuid.uuid4())
 
-    try:
-      locale.setlocale(locale.LC_ALL, '')
-      this_locale = locale.getlocale()[0]
-    except locale.Error:
-      this_locale = "unknown"
-
     log_info = {
       # System-specific information
       'platform' : platform.platform(),
       'runtime' : platform.python_implementation(),
-      'locale' : this_locale,
 
       # Crash-specific information
       'exception' : exception.__class__.__name__,

--- a/test/test_local_state.py
+++ b/test/test_local_state.py
@@ -4,7 +4,6 @@
 
 # General-purpose Python library imports
 import json
-import locale
 import os
 import platform
 import re
@@ -310,9 +309,6 @@ class TestLocalState(unittest.TestCase):
     platform.should_receive('platform').and_return("MyOS")
     platform.should_receive('python_implementation').and_return("MyPython")
 
-    flexmock(locale)
-    locale.should_receive('getlocale').and_return(("'Murica", None))
-
     # Mock out writing it to the crash log file
     expected = '{0}log-{1}'.format(LocalState.LOCAL_APPSCALE_PATH,
       crashlog_suffix)
@@ -332,45 +328,6 @@ class TestLocalState(unittest.TestCase):
     actual = LocalState.generate_crash_log(exception, stacktrace)
     self.assertEquals(expected, actual)
 
-
-  def test_generate_crash_log_on_unsupported_locale(self):
-    crashlog_suffix = '123456'
-    flexmock(uuid)
-    uuid.should_receive('uuid4').and_return(crashlog_suffix)
-
-    exception_class = 'Exception'
-    exception_message = 'baz message'
-    exception = Exception(exception_message)
-    stacktrace = "\n".join(['Traceback (most recent call last):',
-      '  File "<stdin>", line 2, in <module>',
-      '{0}: {1}'.format(exception_class, exception_message)])
-
-    # Mock out grabbing our system's information
-    flexmock(platform)
-    platform.should_receive('platform').and_return("MyOS")
-    platform.should_receive('python_implementation').and_return("MyPython")
-
-    flexmock(locale)
-    locale.should_receive('setlocale').and_raise(locale.Error)
-
-    # Mock out writing it to the crash log file
-    expected = '{0}log-{1}'.format(LocalState.LOCAL_APPSCALE_PATH,
-      crashlog_suffix)
-
-    fake_file = flexmock(name='fake_file')
-    fake_file.should_receive('write').with_args(str)
-
-    fake_builtins = flexmock(sys.modules['__builtin__'])
-    fake_builtins.should_call('open')  # set the fall-through
-    fake_builtins.should_receive('open').with_args(expected, 'w').and_return(
-      fake_file)
-
-    # mock out printing the crash log message
-    flexmock(AppScaleLogger)
-    AppScaleLogger.should_receive('warn')
-
-    actual = LocalState.generate_crash_log(exception, stacktrace)
-    self.assertEquals(expected, actual)
 
   def test_get_key_path_from_local_appscale(self):
     keyname = "keyname"


### PR DESCRIPTION
The function can be problematic on some systems, and we don't
want to get in the way of generating a crashlog.