### PR TITLE
Use older version of wstools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,8 @@ setup(
     'oauth2client>=2.0.0',
     'PyYAML',
     'SOAPpy',
-    'termcolor'
+    'termcolor',
+    'wstools==0.4.3'
   ],
   classifiers=[
     'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
This is a dependency for SOAPpy.
0.4.4 does not build with setuptools.