### PR TITLE
Ensure the tools are up-to-date before upgrade

### DIFF
--- a/appscale/tools/appscale_tools.py
+++ b/appscale/tools/appscale_tools.py
@@ -771,8 +771,13 @@ class AppScaleTools(object):
         'Checking if an update is available for appscale-tools')
       latest_tools = latest_tools_version()
     except:
-      # Continue if version metadata can't be fetched.
-      pass
+      # Prompt the user if version metadata can't be fetched.
+      if not options.test:
+        response = raw_input(
+          'Unable to check for the latest version of appscale-tools. Would '
+          'you like to continue upgrading anyway? (y/N) ')
+        if response.lower() not in ['y', 'yes']:
+          raise AppScaleException('Cancelled AppScale upgrade.')
 
     if latest_tools > APPSCALE_VERSION:
       raise AppScaleException(

--- a/appscale/tools/appscale_tools.py
+++ b/appscale/tools/appscale_tools.py
@@ -32,6 +32,7 @@ from local_state import APPSCALE_VERSION
 from local_state import LocalState
 from node_layout import NodeLayout
 from remote_helper import RemoteHelper
+from version_helper import latest_tools_version
 
 
 def async_layout_upgrade(ip, keyname, script, error_bucket, verbose=False):
@@ -763,6 +764,21 @@ class AppScaleTools(object):
     if not node_layout.is_valid():
       raise BadConfigurationException(
         'Your ips_layout is invalid:\n{}'.format(node_layout.errors()))
+
+    latest_tools = APPSCALE_VERSION
+    try:
+      AppScaleLogger.log(
+        'Checking if an update is available for appscale-tools')
+      latest_tools = latest_tools_version()
+    except:
+      # Continue if version metadata can't be fetched.
+      pass
+
+    if latest_tools > APPSCALE_VERSION:
+      raise AppScaleException(
+        "There is a newer version ({}) of appscale-tools available. Please "
+        "upgrade the tools package before running 'appscale upgrade'.".
+        format(latest_tools))
 
     master_ip = node_layout.head_node().public_ip
     upgrade_version_available = cls.get_upgrade_version_available()

--- a/appscale/tools/version_helper.py
+++ b/appscale/tools/version_helper.py
@@ -10,7 +10,23 @@ AppScale Tools.
 
 
 # First-party Python libraries
+import json
 import sys
+import urllib2
+
+# The location of appscale-tools on PyPI.
+PYPI_URL = 'https://pypi.python.org/pypi/appscale-tools'
+
+
+def latest_tools_version():
+  """ Fetches the latest tools version available on PyPI.
+
+  Returns:
+    A string containing a version number.
+  """
+  response = urllib2.urlopen('{}/json'.format(PYPI_URL))
+  pypi_info = json.loads(response.read())
+  return pypi_info['info']['version']
 
 
 def ensure_valid_python_is_used(system=sys):


### PR DESCRIPTION
If any changes are made to the upgrade process on the AppScale side, then trying an upgrade with an older version of the tools may not work.