### PR TITLE
Catch struct.error when importing AzureAgent

### DIFF
--- a/appscale/tools/agents/factory.py
+++ b/appscale/tools/agents/factory.py
@@ -1,11 +1,9 @@
-import logging
 import struct
 
 from appscale.tools.custom_exceptions import UnknownInfrastructureException
 try:
   from azure_agent import AzureAgent
 except (ImportError, struct.error):
-  logging.exception('AzureAgent disabled')
   AzureAgent = None
 from ec2_agent import EC2Agent
 from euca_agent import EucalyptusAgent

--- a/appscale/tools/agents/factory.py
+++ b/appscale/tools/agents/factory.py
@@ -1,7 +1,11 @@
+import logging
+import struct
+
 from appscale.tools.custom_exceptions import UnknownInfrastructureException
 try:
   from azure_agent import AzureAgent
-except ImportError:
+except (ImportError, struct.error):
+  logging.exception('AzureAgent disabled')
   AzureAgent = None
 from ec2_agent import EC2Agent
 from euca_agent import EucalyptusAgent


### PR DESCRIPTION
Currently, msrestazure 0.4.2 is not working properly on Precise.
```
>>> import msrestazure.azure_active_directory
struct.error: unpack requires a string argument of length 4
```