### PR TITLE
Require a specific version of adal

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
   keywords='appscale google-app-engine python java go php',
   platforms='Posix; MacOS X',
   install_requires=[
-    'adal',
+    'adal==0.4.0',
     'cryptography',
     'argparse',
     'boto',


### PR DESCRIPTION
0.4.1 does not install correctly without jwt.