### PR TITLE
Remove version check from setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import glob
 import sys
 
-from appscale.tools import version_helper
 from setuptools import setup
 
 # Require users to uninstall versions that used the appscale namespace.
@@ -13,8 +12,6 @@ try:
 except ImportError:
   pass
 
-
-version_helper.ensure_valid_python_is_used()
 
 long_description = """AppScale Tools
 --------------


### PR DESCRIPTION
Existing packages in the appscale namespace may prevent importing from uninstalled tools package. Users will still receive a warning at runtime if they have a Python version older than 2.6.