### PR TITLE
Include extra dependencies in app tarball

### DIFF
--- a/appscale/tools/appscale_tools.py
+++ b/appscale/tools/appscale_tools.py
@@ -698,6 +698,10 @@ class AppScaleTools(object):
       file_location)
     AppEngineHelper.validate_app_id(app_id)
 
+    extras = {}
+    if app_language == 'go':
+      extras = LocalState.get_extra_go_dependencies(options.file)
+
     if app_language == 'java':
       if AppEngineHelper.is_sdk_mismatch(file_location):
         AppScaleLogger.warn('AppScale did not find the correct SDK jar ' +
@@ -738,7 +742,7 @@ class AppScaleTools(object):
       AppScaleLogger.log("Ignoring .pyc files")
 
     remote_file_path = RemoteHelper.copy_app_to_host(file_location,
-      options.keyname, options.verbose)
+      options.keyname, options.verbose, extras)
 
     acc.done_uploading(app_id, remote_file_path)
     acc.update([app_id])

--- a/appscale/tools/appscale_tools.py
+++ b/appscale/tools/appscale_tools.py
@@ -700,7 +700,7 @@ class AppScaleTools(object):
 
     extras = {}
     if app_language == 'go':
-      extras = LocalState.get_extra_go_dependencies(options.file)
+      extras = LocalState.get_extra_go_dependencies(options.file, options.test)
 
     if app_language == 'java':
       if AppEngineHelper.is_sdk_mismatch(file_location):

--- a/appscale/tools/local_state.py
+++ b/appscale/tools/local_state.py
@@ -1193,11 +1193,12 @@ class LocalState(object):
     return False
 
   @classmethod
-  def get_extra_go_dependencies(cls, app_base):
+  def get_extra_go_dependencies(cls, app_base, test=False):
     """ Collects a list of additional source files to include in the Go app.
 
     Args:
       app_base: A string specifying the application directory.
+      test: A boolean indicating that the user does not want to be prompted.
     Returns:
       A dictionary mapping file names to their location on the file system.
     """
@@ -1207,33 +1208,42 @@ class LocalState(object):
 
     goroot = os.getenv('GOROOT', None)
     if goroot is None:
-      confirm = raw_input(
-        'The GOROOT environment variable is not defined. Some of your '
-        'dependencies may be excluded.\n'
-        'Continue anyway? (Y/n) ')
-      if confirm.lower() in ['n', 'no']:
-        raise AppScaleException('Your application was not deployed.')
+      message = ('The GOROOT environment variable is not defined. Some of '
+        'your dependencies may be excluded.')
+
+      if test:
+        AppScaleLogger.log(message)
+      else:
+        confirm = raw_input('{}\nContinue anyway? (Y/n) '.format(message))
+        if confirm.lower() in ['n', 'no']:
+          raise AppScaleException('Your application was not deployed.')
       return {}
 
     gab = os.path.join(goroot, 'bin', 'go-app-builder')
     if not os.path.isfile(gab):
-      confirm = raw_input(
-        'Unable to find bin/go-app-builder in GOROOT ({}). Some of your '
-        'dependencies may be excluded. The goroot included with the App '
-        'Engine Go SDK should have this. \n'
-        'Continue anyway? (Y/n) '.format(goroot))
-      if confirm.lower() in ['n', 'no']:
-        raise AppScaleException('Your application was not deployed.')
+      message = ('Unable to find bin/go-app-builder in GOROOT ({}). Some of '
+        'your dependencies may be excluded. The goroot included with the App '
+        'Engine Go SDK should have this.'.format(goroot))
+
+      if test:
+        AppScaleLogger.log(message)
+      else:
+        confirm = raw_input('{}\nContinue anyway? (Y/n) '.format(message))
+        if confirm.lower() in ['n', 'no']:
+          raise AppScaleException('Your application was not deployed.')
       return {}
 
     gopath = os.getenv('GOPATH', None)
     if gopath is None:
-      confirm = raw_input(
-        'The GOPATH environment variable is not defined. Some of your '
-        'dependencies may be excluded.\n'
-        'Continue anyway? (Y/n) ')
-      if confirm.lower() in ['n', 'no']:
-        raise AppScaleException('Your application was not deployed.')
+      message = ('The GOPATH environment variable is not defined. Some of '
+        'your dependencies may be excluded.')
+
+      if test:
+        AppScaleLogger.log(message)
+      else:
+        confirm = raw_input('{}\nContinue anyway? (Y/n) '.format(message))
+        if confirm.lower() in ['n', 'no']:
+          raise AppScaleException('Your application was not deployed.')
       return {}
 
     go_files = []
@@ -1254,13 +1264,16 @@ class LocalState(object):
     try:
       gab_output = subprocess.check_output(gab_args)
     except subprocess.CalledProcessError:
-      confirm = raw_input(
-        'The go-app-builder command failed. Some of your dependencies may be '
-        'excluded.\n'
-        'The command run was "{}"\n'
-        'Continue anyway? (Y/n) '.format(' '.join(gab_args)))
-      if confirm.lower() in ['n', 'no']:
-        raise AppScaleException('Your application was not deployed.')
+      message = ('The go-app-builder command failed. Some of your '
+        'dependencies may be excluded.\n'
+        'The command run was "{}".'.format(' '.join(gab_args)))
+
+      if test:
+        AppScaleLogger.log(message)
+      else:
+        confirm = raw_input('{}\nContinue anyway? (Y/n) '.format(message))
+        if confirm.lower() in ['n', 'no']:
+          raise AppScaleException('Your application was not deployed.')
       return {}
 
     extras = {}

--- a/appscale/tools/local_state.py
+++ b/appscale/tools/local_state.py
@@ -1247,7 +1247,7 @@ class LocalState(object):
       return {}
 
     go_files = []
-    for root, dirnames, filenames in os.walk(app_base):
+    for root, _, filenames in os.walk(app_base):
       relative_dir = os.path.relpath(root, app_base)
       for filename in fnmatch.filter(filenames, '*.go'):
         relative_path = os.path.join(relative_dir, filename)

--- a/appscale/tools/remote_helper.py
+++ b/appscale/tools/remote_helper.py
@@ -941,7 +941,7 @@ class RemoteHelper(object):
 
 
   @classmethod
-  def copy_app_to_host(cls, app_location, keyname, is_verbose):
+  def copy_app_to_host(cls, app_location, keyname, is_verbose, extras=None):
     """Copies the given application to a machine running the Login service
     within an AppScale deployment.
 
@@ -952,6 +952,7 @@ class RemoteHelper(object):
         AppScale deployment.
       is_verbose: A bool that indicates if we should print the commands we exec
         to copy the app to the remote host to stdout.
+      extras: A dictionary containing a list of files to include in the upload.
 
     Returns:
       A str corresponding to the location on the remote filesystem where the
@@ -974,6 +975,9 @@ class RemoteHelper(object):
           continue
         relative_path = os.path.join(relative_dir, filename)
         app_files[relative_path] = os.path.join(root, filename)
+
+    if extras is not None:
+      app_files.update(extras)
 
     with tarfile.open(local_tarred_app, 'w:gz') as app_tar:
       for tarball_path in app_files:

--- a/appscale/tools/remote_helper.py
+++ b/appscale/tools/remote_helper.py
@@ -967,7 +967,7 @@ class RemoteHelper(object):
 
     # Collect list of files that should be included in the tarball.
     app_files = {}
-    for root, dirnames, filenames in os.walk(app_location):
+    for root, _, filenames in os.walk(app_location):
       relative_dir = os.path.relpath(root, app_location)
       for filename in filenames:
         # Ignore compiled Python files.

--- a/test/test_appscale_upload_app.py
+++ b/test/test_appscale_upload_app.py
@@ -30,6 +30,7 @@ from appscale.tools.custom_exceptions import AppEngineConfigException
 from appscale.tools.custom_exceptions import AppScaleException
 from appscale.tools.local_state import LocalState
 from appscale.tools.parse_args import ParseArgs
+from appscale.tools.remote_helper import RemoteHelper
 
 
 class TestAppScaleUploadApp(unittest.TestCase):
@@ -760,12 +761,14 @@ class TestAppScaleUploadApp(unittest.TestCase):
     app_stats_data = {'apps': {'baz': {'http': 8080, 'language': 'python27',
       'total_reqs': 'no_change', 'appservers': 1, 'https': 4380, 'reqs_enqueued': None}}}
 
+    remote_tarball = '/opt/appscale/apps/baz.tar.gz'
+
     # mock out the SOAP call to the AppController and assume it succeeded
     fake_appcontroller = flexmock(name='fake_appcontroller')
     fake_appcontroller.should_receive('status').with_args('the secret') \
       .and_return('Database is at public1')
     fake_appcontroller.should_receive('done_uploading').with_args('baz',
-      '/opt/appscale/apps/baz.tar.gz', 'the secret').and_return()
+      remote_tarball, 'the secret').and_return()
     fake_appcontroller.should_receive('update').with_args(['baz'],
       'the secret').and_return()
     fake_appcontroller.should_receive('is_app_running').with_args('baz',
@@ -842,6 +845,9 @@ class TestAppScaleUploadApp(unittest.TestCase):
     flexmock(socket)
     socket.should_receive('socket').and_return(fake_socket)
 
+    flexmock(RemoteHelper).should_receive('copy_app_to_host').\
+      and_return(remote_tarball)
+
     argv = [
       "--keyname", self.keyname,
       "--file", self.app_dir + ".tar.gz"
@@ -893,12 +899,14 @@ class TestAppScaleUploadApp(unittest.TestCase):
     app_stats_data = {'apps': {'baz': {'http': 8080, 'language': 'python27',
       'total_reqs': 'no_change', 'appservers': 1, 'https': 4380, 'reqs_enqueued': None}}}
 
+    remote_tarball = '/opt/appscale/apps/baz.tar.gz'
+
     # mock out the SOAP call to the AppController and assume it succeeded
     fake_appcontroller = flexmock(name='fake_appcontroller')
     fake_appcontroller.should_receive('status').with_args('the secret') \
       .and_return('Database is at public1')
     fake_appcontroller.should_receive('done_uploading').with_args('baz',
-      '/opt/appscale/apps/baz.tar.gz', 'the secret').and_return()
+      remote_tarball, 'the secret').and_return()
     fake_appcontroller.should_receive('update').with_args(['baz'],
       'the secret').and_return()
     fake_appcontroller.should_receive('is_app_running').with_args('baz',
@@ -974,6 +982,9 @@ class TestAppScaleUploadApp(unittest.TestCase):
       .and_return(None)
     flexmock(socket)
     socket.should_receive('socket').and_return(fake_socket)
+
+    flexmock(RemoteHelper).should_receive('copy_app_to_host').\
+      and_return(remote_tarball)
 
     argv = [
       "--keyname", self.keyname,


### PR DESCRIPTION
This uses the go-app-builder binary to discover the application's dependencies. The user must have a suitable `GOROOT` (that includes `bin/go-app-builder`) and `GOPATH` defined as environment variables in order for it to work.

If there is an issue discovering the required dependencies, the user will be prompted if they want to continue.