### PR TITLE
Require setuptools>=11.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     'oauth2client==4.0.0',
     'PyYAML',
     'requests>=2.7.0',
-    'setuptools<34',
+    'setuptools>=11.3,<34',
     'SOAPpy',
     'termcolor',
     'wstools==0.4.3'


### PR DESCRIPTION
Earlier versions don't support new syntax when parsing dependency requirements.