### PR TITLE
Azure agent returns public IPs only for load balancers

### DIFF
--- a/appscale/tools/agents/azure_agent.py
+++ b/appscale/tools/agents/azure_agent.py
@@ -309,6 +309,9 @@ class AzureAgent(BaseAgent):
     subnet = self.create_virtual_network(network_client, parameters,
                                          virtual_network, virtual_network)
 
+    active_public_ips, active_private_ips, active_instances = \
+      self.describe_instances(parameters)
+
     if public_ip_needed:
       for _ in range(count):
         vm_network_name = Haikunator().haikunate()
@@ -322,6 +325,10 @@ class AzureAgent(BaseAgent):
       self.create_or_update_vm_scale_sets(count, parameters, subnet)
 
     public_ips, private_ips, instance_ids = self.describe_instances(parameters)
+    public_ips = self.diff(public_ips, active_public_ips)
+    private_ips = self.diff(private_ips, active_private_ips)
+    instance_ids = self.diff(instance_ids, active_instances)
+
     return instance_ids, public_ips, private_ips
 
   def create_virtual_machine(self, credentials, network_client, network_id,

--- a/appscale/tools/agents/azure_agent.py
+++ b/appscale/tools/agents/azure_agent.py
@@ -146,7 +146,7 @@ class AzureAgent(BaseAgent):
   MAX_VMSS_WAIT_TIME = 300
 
   # The maximum limit of allowable VMs within a scale set.
-  MAX_VMSS_CAPACITY = 40
+  MAX_VMSS_CAPACITY = 20
 
   # The Virtual Network and Subnet name to use while creating an Azure
   # Virtual machine.

--- a/appscale/tools/agents/base_agent.py
+++ b/appscale/tools/agents/base_agent.py
@@ -66,7 +66,7 @@ class BaseAgent:
     raise NotImplementedError
 
 
-  def run_instances(self, count, parameters, security_configured):
+  def run_instances(self, count, parameters, security_configured, public_ip_needed):
     """Start a set of virtual machines using the parameters provided.
 
     Args:

--- a/appscale/tools/agents/ec2_agent.py
+++ b/appscale/tools/agents/ec2_agent.py
@@ -375,7 +375,7 @@ class EC2Agent(BaseAgent):
         private_ips.append(i.private_ip_address)
     return public_ips, private_ips, instance_ids
 
-  def run_instances(self, count, parameters, security_configured):
+  def run_instances(self, count, parameters, security_configured, public_ip_needed):
     """
     Spawns the specified number of EC2 instances using the parameters
     provided. This method is blocking in that it waits until the

--- a/appscale/tools/agents/gce_agent.py
+++ b/appscale/tools/agents/gce_agent.py
@@ -725,7 +725,7 @@ class GCEAgent(BaseAgent):
       project_url, parameters[self.PARAM_ZONE], disk_name)
     return disk_url
 
-  def run_instances(self, count, parameters, security_configured):
+  def run_instances(self, count, parameters, security_configured, public_ip_needed):
     """ Starts 'count' instances in Google Compute Engine, and returns once they
     have been started.
 

--- a/appscale/tools/parse_args.py
+++ b/appscale/tools/parse_args.py
@@ -95,9 +95,10 @@ class ParseArgs(object):
     "Standard_DS4", "Standard_DS11", "Standard_DS12", "Standard_DS13",
     "Standard_DS14", "Standard_DS2_v2", "Standard_DS3_v2", "Standard_DS4_v2",
     "Standard_DS5_v2", "Standard_DS11_v2", "Standard_DS12_v2", "Standard_DS13_v2",
-    "Standard_DS14_v2", "Standard_DS15_v2", "Standard_G1", "Standard_G2",
-    "Standard_G3", "Standard_G4", "Standard_G5", "Standard_GS1", "Standard_GS2",
-    "Standard_GS3", "Standard_GS4", "Standard_GS5"]
+    "Standard_DS14_v2", "Standard_DS15_v2", "Standard_F4", "Standard_F8",
+    "Standard_F16", "Standard_F4s", "Standard_F8s", "Standard_F16s"
+    "Standard_G1", "Standard_G2", "Standard_G3", "Standard_G4", "Standard_G5",
+    "Standard_GS1", "Standard_GS2", "Standard_GS3", "Standard_GS4", "Standard_GS5"]
 
   # A combined list of instance types for the different cloud infrastructures.
   ALLOWED_INSTANCE_TYPES = ALLOWED_EC2_INSTANCE_TYPES + ALLOWED_GCE_INSTANCE_TYPES + \

--- a/appscale/tools/remote_helper.py
+++ b/appscale/tools/remote_helper.py
@@ -283,7 +283,8 @@ class RemoteHelper(object):
         that was started.
     """
     instance_ids, public_ips, private_ips = agent.run_instances(
-      count=count, parameters=params, security_configured=True)
+      count=count, parameters=params, security_configured=True,
+      public_ip_needed=True)
 
     if options.static_ip:
       agent.associate_static_ip(params, instance_ids[0], options.static_ip)
@@ -308,7 +309,8 @@ class RemoteHelper(object):
         that was started.
     """
     instance_ids, public_ips, private_ips = agent.run_instances(
-      count=count, parameters=params, security_configured=True)
+      count=count, parameters=params, security_configured=True,
+      public_ip_needed=False)
     return instance_ids, public_ips, private_ips
 
   @classmethod


### PR DESCRIPTION
This PR has added an additional flag for agents to return public IPs only if needed for load balancer role. Azure agent is the only one currently to implement that functionality and rest of the agents will follow later.