### PR TITLE
Fix verbose mode during azure terminate

### DIFF
--- a/appscale/tools/agents/azure_agent.py
+++ b/appscale/tools/agents/azure_agent.py
@@ -113,7 +113,7 @@ class AzureAgent(BaseAgent):
   PARAM_TENANT_ID = 'azure_tenant_id'
   PARAM_TEST = 'test'
   PARAM_TAG = 'azure_group_tag'
-  PARAM_VERBOSE = 'is_verbose'
+  PARAM_VERBOSE = 'IS_VERBOSE'
   PARAM_ZONE = 'zone'
 
   # A set that contains all of the items necessary to run AppScale in Azure.


### PR DESCRIPTION
When we terminate cloud instances, we set the verbose flag on an 'IS_VERBOSE' parameter which was different from the lower case parameter used while running instances. This PR makes sure that while terminating azure instances output is less verbose unless specified.