### PR TITLE
Use AppScalefile as fallback source for IPs

### DIFF
--- a/appscale/tools/appengine_helper.py
+++ b/appscale/tools/appengine_helper.py
@@ -3,6 +3,7 @@
 
 # General-purpose Python libraries
 import os
+import socket
 import re
 import yaml
 
@@ -260,3 +261,27 @@ class AppEngineHelper(object):
     if not cls.APP_ID_REGEX.match(app_id):
       raise AppEngineConfigException("Invalid application ID. You can only" + \
         " use alphanumeric characters and/or '-'.")
+
+  @classmethod
+  def is_valid_ipv4_address(cls, address):
+    """ Determines whether or not a string is an IP address.
+
+    Args:
+      address: A string containing a potential address.
+    Returns:
+      A boolean indicating whether or not the string is a valid IP address.
+    """
+    try:
+      socket.inet_pton(socket.AF_INET, address)
+    except AttributeError:
+      # The inet_pton function is not available on all platforms.
+      try:
+        socket.inet_aton(address)
+      except socket.error:
+        return False
+      # Reject shortened addresses.
+      return address.count('.') == 3
+    except socket.error:
+      return False
+
+    return True

--- a/appscale/tools/appscale.py
+++ b/appscale/tools/appscale.py
@@ -337,7 +337,11 @@ Available commands:
     if not os.path.exists(ssh_key_location):
       return False
 
-    all_ips = LocalState.get_all_public_ips(keyname)
+    try:
+      all_ips = LocalState.get_all_public_ips(keyname)
+    except BadConfigurationException:
+      # If this is an upgrade from 3.1.0, there may not be a locations JSON.
+      all_ips = set(run_instances_opts.ips.values())
 
     # If a login node is defined, use that to communicate with other nodes.
     node_layout = NodeLayout(run_instances_opts)

--- a/appscale/tools/appscale.py
+++ b/appscale/tools/appscale.py
@@ -23,6 +23,7 @@ from custom_exceptions import ShellException
 
 
 # AppScale-specific imports
+from appengine_helper import AppEngineHelper
 from appscale_tools import AppScaleTools
 from local_state import LocalState
 from node_layout import NodeLayout
@@ -342,6 +343,8 @@ Available commands:
     except BadConfigurationException:
       # If this is an upgrade from 3.1.0, there may not be a locations JSON.
       all_ips = set(run_instances_opts.ips.values())
+      assert all(AppEngineHelper.is_valid_ipv4_address(ip) for ip in all_ips),\
+        'Invalid IP address in {}'.format(all_ips)
 
     # If a login node is defined, use that to communicate with other nodes.
     node_layout = NodeLayout(run_instances_opts)

--- a/test/test_appengine_helper.py
+++ b/test/test_appengine_helper.py
@@ -1,0 +1,15 @@
+import unittest
+
+from appscale.tools.appengine_helper import AppEngineHelper
+
+
+class TestAppEngineHelper(unittest.TestCase):
+  def test_is_valid_ipv4_address(self):
+    to_test = {'192.168.33.10': True,
+               '10.10.1.0': True,
+               'node-1': False,
+               '2001:0DB8:AC10:FE01::': False}
+    for test_ip, should_be_valid in to_test.iteritems():
+      self.assertEqual(AppEngineHelper.is_valid_ipv4_address(test_ip),
+                       should_be_valid,
+                       '{} should be {}'.format(test_ip, should_be_valid))


### PR DESCRIPTION
After an upgrade from <= 3.1.0, the user may not have a locations JSON file. This change allows the tools to still check if the ssh key is valid by using the AppScalefile to generate a list of all addresses in a cluster.