### PR TITLE
Increase default timeout

### DIFF
--- a/appscale/tools/appscale_tools.py
+++ b/appscale/tools/appscale_tools.py
@@ -87,7 +87,7 @@ class AppScaleTools(object):
 
 
   # The number of seconds to wait before giving up on an operation.
-  MAX_OPERATION_TIME = 100
+  MAX_OPERATION_TIME = 200
 
 
   # The location of the expect script, used to interact with ssh-copy-id


### PR DESCRIPTION
The backend deployment timeout is 180, and once you add 2 duty cycles,
it could take (theoretically) up to 200 seconds to respond.