### PR TITLE
Use a valid version ID when deploying

### DIFF
--- a/appscale/tools/admin_client.py
+++ b/appscale/tools/admin_client.py
@@ -6,8 +6,9 @@ import yaml
 # The default service.
 DEFAULT_SERVICE = 'default'
 
-# The default version.
-DEFAULT_VERSION = 'default'
+# The version that AppScale uses. This is temporary until we support multiple
+# versions per service.
+DEFAULT_VERSION = '1'
 
 
 class AdminError(Exception):

--- a/appscale/tools/admin_client.py
+++ b/appscale/tools/admin_client.py
@@ -8,7 +8,7 @@ DEFAULT_SERVICE = 'default'
 
 # The version that AppScale uses. This is temporary until we support multiple
 # versions per service.
-DEFAULT_VERSION = '1'
+DEFAULT_VERSION = 'v1'
 
 
 class AdminError(Exception):

--- a/appscale/tools/appengine_helper.py
+++ b/appscale/tools/appengine_helper.py
@@ -217,7 +217,10 @@ class AppEngineHelper(object):
       app_config = ElementTree.parse(app_config_file).getroot()
       namespace = '{http://appengine.google.com/ns/1.0}'
       if app_config.find('{}version'.format(namespace)) is not None:
-        module = app_config.find('{}version'.format(namespace)) or 'default'
+        module = app_config.find('{}module'.format(namespace))
+        if module is None:
+          module = 'default'
+
         message = ('The version element is not supported in appengine-web.xml.'
                    ' Module {} will be overwritten.'.format(module))
 

--- a/appscale/tools/appengine_helper.py
+++ b/appscale/tools/appengine_helper.py
@@ -6,10 +6,13 @@ import os
 import socket
 import re
 import yaml
+from xml.etree import ElementTree
 
 
 # AppScale-specific imports
-from custom_exceptions import AppEngineConfigException
+from .appscale_logger import AppScaleLogger
+from .custom_exceptions import AppEngineConfigException
+from .custom_exceptions import AppScaleException
 
 
 class AppEngineHelper(object):
@@ -191,6 +194,39 @@ class AppEngineHelper(object):
         raise AppEngineConfigException("No application ID found in " +
           "your appengine-web.xml. " + cls.REGEX_MESSAGE)
 
+  @classmethod
+  def warn_if_version_defined(cls, app_dir, test=False):
+    """ Warns the user if version is defined in the application configuration.
+
+    Args:
+      app_dir: The directory on the local filesystem where the App Engine
+        application can be found.
+      test: A boolean indicating that the tools are in test mode.
+    Raises:
+      AppScaleException: If version is defined and user decides to cancel.
+    """
+    message = ''
+    app_config_file = cls.get_config_file_from_dir(app_dir)
+    if cls.FILE_IS_YAML.search(app_config_file):
+      yaml_contents = yaml.safe_load(cls.read_file(app_config_file))
+      if yaml_contents.get('version') is not None:
+        module = yaml_contents.get('module', 'default')
+        message = ('The version element is not supported in app.yaml. '
+                   'Module {} will be overwritten.'.format(module))
+    else:
+      app_config = ElementTree.parse(app_config_file).getroot()
+      namespace = '{http://appengine.google.com/ns/1.0}'
+      if app_config.find('{}version'.format(namespace)) is not None:
+        module = app_config.find('{}version'.format(namespace)) or 'default'
+        message = ('The version element is not supported in appengine-web.xml.'
+                   ' Module {} will be overwritten.'.format(module))
+
+    if message:
+      AppScaleLogger.log(message)
+      if not test:
+        response = raw_input('Continue? (y/N) ')
+        if response.lower() not in ['y', 'yes']:
+          raise AppScaleException('Cancelled deploy operation')
 
   @classmethod
   def get_app_runtime_from_app_config(cls, app_dir):

--- a/appscale/tools/appscale_tools.py
+++ b/appscale/tools/appscale_tools.py
@@ -903,6 +903,9 @@ class AppScaleTools(object):
       file_location = file_location + os.sep + ".."
       app_id = AppEngineHelper.get_app_id_from_app_config(file_location)
 
+    # Let users know that versions are not supported yet.
+    AppEngineHelper.warn_if_version_defined(file_location, options.test)
+
     app_language = AppEngineHelper.get_app_runtime_from_app_config(
       file_location)
     threadsafe = None

--- a/test/test_appscale_upload_app.py
+++ b/test/test_appscale_upload_app.py
@@ -143,6 +143,7 @@ class TestAppScaleUploadApp(unittest.TestCase):
     flexmock(AppEngineHelper).should_receive('get_app_id_from_app_config').and_return('app_id')
     flexmock(AppEngineHelper).should_receive('get_app_runtime_from_app_config').and_return('runtime')
     flexmock(LocalState).should_receive('get_secret_key').and_return()
+    flexmock(AppEngineHelper).should_receive('warn_if_version_defined')
 
     # mock out reading the app.yaml file
     builtins = flexmock(sys.modules['__builtin__'])
@@ -313,6 +314,7 @@ class TestAppScaleUploadApp(unittest.TestCase):
     flexmock(AdminClient).should_receive('get_operation').\
       and_return({'done': True, 'response': {'versionUrl': version_url}})
     flexmock(shutil).should_receive('rmtree').with_args(extracted_dir)
+    flexmock(AppEngineHelper).should_receive('warn_if_version_defined')
 
     given_host, given_port = AppScaleTools.upload_app(options)
     self.assertEquals(given_host, login_host)


### PR DESCRIPTION
This always uses '1' as the version for the service being deployed. 'default' is not valid in App Engine.