### PR TITLE
Add instance ID only when a private IP is assigned to the instance.

### DIFF
--- a/appscale/tools/agents/azure_agent.py
+++ b/appscale/tools/agents/azure_agent.py
@@ -287,14 +287,15 @@ class AzureAgent(BaseAgent):
           list_virtual_machine_scale_set_vm_network_interfaces(resource_group,
                                                                vmss.name,
                                                                vm.instance_id)
-        ip_config_private_ips = []
+        ip_config_private_ip = None
         for network_interface in network_interface_list:
           for ip_config in network_interface.ip_configurations:
-            ip_config_private_ips.append(ip_config.private_ip_address)
+            ip_config_private_ip = ip_config.private_ip_address
+            break
 
-        if ip_config_private_ips:
-          public_ips.append(ip_config_private_ips[0])
-          private_ips.append(ip_config_private_ips[0])
+        if ip_config_private_ip:
+          public_ips.append(ip_config_private_ip)
+          private_ips.append(ip_config_private_ip)
           instance_ids.append(vm.name)
 
     return public_ips, private_ips, instance_ids

--- a/appscale/tools/agents/azure_agent.py
+++ b/appscale/tools/agents/azure_agent.py
@@ -283,14 +283,16 @@ class AzureAgent(BaseAgent):
       vm_list = compute_client.virtual_machine_scale_set_vms.list(resource_group,
                                                                   vmss.name)
       for vm in vm_list:
-        instance_ids.append(vm.name)
-      network_interface_list = network_client.network_interfaces.\
-        list_virtual_machine_scale_set_network_interfaces(resource_group,
-                                                          vmss.name)
-      for network_interface in network_interface_list:
-        for ip_config in network_interface.ip_configurations:
-          public_ips.append(ip_config.private_ip_address)
-          private_ips.append(ip_config.private_ip_address)
+        network_interface_list = network_client.network_interfaces. \
+          list_virtual_machine_scale_set_vm_network_interfaces(resource_group,
+                                                               vmss.name,
+                                                               vm.instance_id)
+        for network_interface in network_interface_list:
+          for ip_config in network_interface.ip_configurations:
+            if ip_config.private_ip_address:
+              public_ips.append(ip_config.private_ip_address)
+              private_ips.append(ip_config.private_ip_address)
+              instance_ids.append(vm.name)
 
     return public_ips, private_ips, instance_ids
 

--- a/appscale/tools/agents/azure_agent.py
+++ b/appscale/tools/agents/azure_agent.py
@@ -293,6 +293,9 @@ class AzureAgent(BaseAgent):
             ip_config_private_ip = ip_config.private_ip_address
             break
 
+          if ip_config_private_ip:
+            break
+
         if ip_config_private_ip:
           public_ips.append(ip_config_private_ip)
           private_ips.append(ip_config_private_ip)

--- a/appscale/tools/agents/azure_agent.py
+++ b/appscale/tools/agents/azure_agent.py
@@ -287,12 +287,15 @@ class AzureAgent(BaseAgent):
           list_virtual_machine_scale_set_vm_network_interfaces(resource_group,
                                                                vmss.name,
                                                                vm.instance_id)
+        ip_config_private_ips = []
         for network_interface in network_interface_list:
           for ip_config in network_interface.ip_configurations:
-            if ip_config.private_ip_address:
-              public_ips.append(ip_config.private_ip_address)
-              private_ips.append(ip_config.private_ip_address)
-              instance_ids.append(vm.name)
+            ip_config_private_ips.append(ip_config.private_ip_address)
+
+        if ip_config_private_ips:
+          public_ips.append(ip_config_private_ips[0])
+          private_ips.append(ip_config_private_ips[0])
+          instance_ids.append(vm.name)
 
     return public_ips, private_ips, instance_ids
 


### PR DESCRIPTION
Previously, the instance IDs were added without checking if the instances had been assigned private IPs, which in one case crashed the controller because one of the instances came back without an IP associated with it. This PR fixes that and makes sure the instance has a private IP before adding it to the list.