### PR TITLE
Expand user directories for creds references

### DIFF
--- a/appscale/tools/agents/gce_agent.py
+++ b/appscale/tools/agents/gce_agent.py
@@ -568,9 +568,11 @@ class GCEAgent(BaseAgent):
       params[self.PARAM_REGION] = self.DEFAULT_REGION
 
     if args.get(self.PARAM_SECRETS):
-      params[self.PARAM_SECRETS] = args.get(self.PARAM_SECRETS)
+      params[self.PARAM_SECRETS] = os.path.expanduser(
+        args.get(self.PARAM_SECRETS))
     elif args.get(self.PARAM_STORAGE):
-      params[self.PARAM_STORAGE] = args.get(self.PARAM_STORAGE)
+      params[self.PARAM_STORAGE] = os.path.expanduser(
+        args.get(self.PARAM_STORAGE))
 
     params[self.PARAM_VERBOSE] = args.get('verbose', False)
     self.assert_credentials_are_valid(params)


### PR DESCRIPTION
This allows users to specify paths that start with '~'.