### PR TITLE
Remove obsolete call to validate node layout

### DIFF
--- a/appscale/tools/appscale_tools.py
+++ b/appscale/tools/appscale_tools.py
@@ -1080,9 +1080,6 @@ class AppScaleTools(object):
         passed in via the command-line interface.
     """
     node_layout = NodeLayout(options)
-    if not node_layout.is_valid():
-      raise BadConfigurationException(
-        'Your ips_layout is invalid:\n{}'.format(node_layout.errors()))
 
     latest_tools = APPSCALE_VERSION
     try:


### PR DESCRIPTION
This is needed for `appscale upgrade` since validation is performed upon object creation now.