### PR TITLE
Do not use regex to parse appengine-web.xml

### DIFF
--- a/test/test_appengine_helper.py
+++ b/test/test_appengine_helper.py
@@ -1,4 +1,7 @@
 import unittest
+from xml.etree import ElementTree
+
+from flexmock import flexmock
 
 from appscale.tools.appengine_helper import AppEngineHelper
 
@@ -13,3 +16,20 @@ class TestAppEngineHelper(unittest.TestCase):
       self.assertEqual(AppEngineHelper.is_valid_ipv4_address(test_ip),
                        should_be_valid,
                        '{} should be {}'.format(test_ip, should_be_valid))
+
+  def test_get_app_id_from_app_config(self):
+    flexmock(AppEngineHelper).should_receive('get_config_file_from_dir').\
+      and_return('appengine-web.xml')
+
+    config_contents = """
+    <?xml version="1.0" encoding="utf-8"?>
+    <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
+        <!-- <application>guestbook1</application> -->
+        <application>guestbook2</application>
+    </appengine-web-app>
+    """.strip()
+    root = ElementTree.fromstring(config_contents)
+    tree = flexmock(getroot=lambda: root)
+    flexmock(ElementTree).should_receive('parse').and_return(tree)
+    self.assertEqual(AppEngineHelper.get_app_id_from_app_config('test_dir'),
+                     'guestbook2')

--- a/test/test_appscale_upload_app.py
+++ b/test/test_appscale_upload_app.py
@@ -247,6 +247,8 @@ class TestAppScaleUploadApp(unittest.TestCase):
     }))
     builtins.should_receive('open').with_args(app_yaml_location, 'r') \
       .and_return(fake_app_yaml)
+    flexmock(AppEngineHelper).should_receive('get_app_id_from_app_config').\
+      and_return('none')
 
     argv = [
       "--keyname", self.keyname,
@@ -275,6 +277,8 @@ class TestAppScaleUploadApp(unittest.TestCase):
     }))
     builtins.should_receive('open').with_args(app_yaml_location, 'r') \
       .and_return(fake_app_yaml)
+    flexmock(AppEngineHelper).should_receive('get_app_id_from_app_config').\
+      and_return('baz*')
 
     argv = [
       "--keyname", self.keyname,


### PR DESCRIPTION
Previously, a commented out application tag could be chosen as the project ID.