### PR TITLE
Fix broken Context Manager reference

### DIFF
--- a/appscale/tools/utils.py
+++ b/appscale/tools/utils.py
@@ -26,8 +26,11 @@ def config_from_tar_gz(file_name, tar_location):
       if len(candidate.name.split('/')) < len(shortest_path.name.split('/')):
         shortest_path = candidate
 
-    with tar.extractfile(shortest_path) as config_file:
+    config_file = tar.extractfile(shortest_path)
+    try:
       return config_file.read()
+    finally:
+      config_file.close()
 
 
 def config_from_zip(file_name, zip_location):


### PR DESCRIPTION
The extractfile method does not support the typical context manager syntax for working with the file object.