### PR TITLE
Error handling for azure agent autoscaling

### DIFF
--- a/appscale/tools/agents/azure_agent.py
+++ b/appscale/tools/agents/azure_agent.py
@@ -918,7 +918,7 @@ class AzureAgent(BaseAgent):
     vmss_delete_threads = []
     vmss_delete_threads_results = []
     index = 0
-    vmss_list_results = self.get_properties(vmss_list, ['name'],
+    vmss_list_results, error = self.get_properties(vmss_list, ['name'],
         raise_exception=True, err_msg="Error terminating instances")
 
     for vmss in vmss_list_results:
@@ -928,7 +928,7 @@ class AzureAgent(BaseAgent):
           resource_group, vmss_name)
       self.raise_if_error(error, "Error terminating instances")
 
-      vm_list_results = self.get_properties(vm_list, ['name'],
+      vm_list_results, error = self.get_properties(vm_list, ['name'],
           raise_exception=True, err_msg="Error terminating instances")
 
       for vm in vm_list_results:
@@ -1050,6 +1050,7 @@ class AzureAgent(BaseAgent):
       results[index] = (error.message,
                         "There was a problem while deleting {0}".format(
                           vm_info))
+      return
     for vm in vm_list_results:
       if instance_id == vm['name']:
         already_deleted = False
@@ -1084,6 +1085,7 @@ class AzureAgent(BaseAgent):
       results[index] = (error.message,
                         "There was a problem while deleting {0}".format(
                           vm_info))
+      return
     for vm in vm_list_results:
       if instance_id == vm['name']:
         results[index] = ("VM still up",

--- a/appscale/tools/agents/azure_agent.py
+++ b/appscale/tools/agents/azure_agent.py
@@ -507,7 +507,7 @@ class AzureAgent(BaseAgent):
     num_instances_added = 0
     vmss_list, error = self.run_and_return_exception(
         compute_client.virtual_machine_scale_sets.list,
-        (resource_group))
+        resource_group)
     if error:
       # This method is not run in a thread so we can directly raise the
       # exception.
@@ -516,7 +516,7 @@ class AzureAgent(BaseAgent):
     for vmss in vmss_list:
       vm_list, error = self.run_and_return_exception(
           compute_client.virtual_machine_scale_set_vms.list,
-          (resource_group, vmss.name))
+          resource_group, vmss.name)
       if error:
         raise AgentRuntimeException("Error adding instances to Scale Set {}: "
                                     "{}".format(vmss.name, error.message))
@@ -529,7 +529,7 @@ class AzureAgent(BaseAgent):
 
       scaleset, error = self.run_and_return_exception(
           compute_client.virtual_machine_scale_sets.get,
-          (resource_group, vmss.name))
+          resource_group, vmss.name)
       if error:
         raise AgentRuntimeException("Error adding instances to Scale Set {}: "
                                     "{}".format(vmss.name, error.message))
@@ -549,7 +549,7 @@ class AzureAgent(BaseAgent):
 
       create_update_response, error = self.run_and_return_exception(
         compute_client.virtual_machine_scale_sets.create_or_update,
-          (resource_group, vmss.name, scaleset))
+          resource_group, vmss.name, scaleset)
       if error:
         raise AgentRuntimeException("There was a problem while updating the "
                                     "Scale Set {0} due to the error: "
@@ -700,7 +700,7 @@ class AzureAgent(BaseAgent):
       virtual_machine_profile=virtual_machine_profile, over_provision=False)
     create_update_response, error = self.run_and_return_exception(
         compute_client.virtual_machine_scale_sets.create_or_update,
-        (resource_group, scale_set_name, vm_scale_set))
+        resource_group, scale_set_name, vm_scale_set)
     if error:
       results[index] = "There was a problem while creating the Scale Set {0} " \
                         "due to the error: {1}".format(scale_set_name,
@@ -764,7 +764,7 @@ class AzureAgent(BaseAgent):
 
     vmss_list, error = self.run_and_return_exception(
         compute_client.virtual_machine_scale_sets.list,
-        (resource_group))
+        resource_group)
     if error:
       raise AgentRuntimeException("Error terminating instances: {}".format(
               error.message))
@@ -783,7 +783,7 @@ class AzureAgent(BaseAgent):
       for vmss in vmss_list:
         vm_list, error = self.run_and_return_exception(
             compute_client.virtual_machine_scale_set_vms.list,
-            (resource_group, vmss.name))
+            resource_group, vmss.name)
         if error:
           raise AgentRuntimeException("Error downscaling: {}".format(
               error.message))
@@ -819,7 +819,7 @@ class AzureAgent(BaseAgent):
       for vmss in vmss_list:
         vm_list, error = self.run_and_return_exception(
             compute_client.virtual_machine_scale_set_vms.list,
-            (resource_group, vmss.name))
+            resource_group, vmss.name)
         if error:
           raise AgentRuntimeException("Error downscaling: {}".format(
               error.message))
@@ -856,7 +856,7 @@ class AzureAgent(BaseAgent):
     for vmss in vmss_list:
       vm_list, error = self.run_and_return_exception(
           compute_client.virtual_machine_scale_set_vms.list,
-          (resource_group, vmss.name))
+          resource_group, vmss.name)
       if error:
         raise AgentRuntimeException("Error terminating instances: {}".format(
             error.message))
@@ -933,7 +933,7 @@ class AzureAgent(BaseAgent):
 
     delete_response, error = self.run_and_return_exception(
           compute_client.virtual_machine_scale_sets.delete,
-          (resource_group, vmss_name))
+          resource_group, vmss_name)
     if error:
       results[index] = (error.message,
           "There was a problem while deleting the Scale Set {0}".format(
@@ -967,7 +967,7 @@ class AzureAgent(BaseAgent):
     # Check if we succeeded deleting the instance before but timed out.
     vm_list, error = self.run_and_return_exception(
         compute_client.virtual_machine_scale_set_vms.list,
-        (resource_group, vmss_name))
+        resource_group, vmss_name)
     if error:
       results[index] = (error.message,
           "There was a problem while deleting {0}".format(vm_info))
@@ -986,7 +986,7 @@ class AzureAgent(BaseAgent):
     AppScaleLogger.verbose("Deleting {0} ...".format(vm_info), verbose)
     result, error = self.run_and_return_exception(
         compute_client.virtual_machine_scale_set_vms.delete,
-        (resource_group, vmss_name, instance_id))
+        resource_group, vmss_name, instance_id)
     if error:
       results[index] = (error.message,
           "There was a problem while deleting {0}".format(vm_info))
@@ -998,7 +998,7 @@ class AzureAgent(BaseAgent):
     # Double check if we succeeded deleting the instance.
     vm_list, error = self.run_and_return_exception(
         compute_client.virtual_machine_scale_set_vms.list,
-        (resource_group, vmss_name))
+        resource_group, vmss_name)
     if error:
       results[index] = (error.message,
           "There was a problem while deleting {0}".format(vm_info))
@@ -1024,7 +1024,7 @@ class AzureAgent(BaseAgent):
 
     # Check if we succeeded deleting the instance before but timed out.
     virtual_machines, error = self.run_and_return_exception(
-        compute_client.virtual_machines.list, (resource_group))
+        compute_client.virtual_machines.list, resource_group)
     if error:
       return "There was a problem while deleting the Virtual Machine {0} due " \
              "to the error: {1}".format(vm_name, error.message)
@@ -1040,7 +1040,7 @@ class AzureAgent(BaseAgent):
 
     AppScaleLogger.verbose("Deleting Virtual Machine {} ...".format(vm_name), verbose)
     result, error = self.run_and_return_exception(
-        compute_client.virtual_machines.delete, (resource_group, vm_name))
+        compute_client.virtual_machines.delete, resource_group, vm_name)
     if error:
       return "There was a problem while deleting the Virtual Machine {0} due " \
              "to the error: {1}".format(vm_name, error.message)
@@ -1051,7 +1051,7 @@ class AzureAgent(BaseAgent):
 
     # Double check if we succeeded deleting the instance.
     virtual_machines, error = self.run_and_return_exception(
-        compute_client.virtual_machines.list, (resource_group))
+        compute_client.virtual_machines.list, resource_group)
     if error:
       return "There was a problem while deleting the Virtual Machine {0} due " \
              "to the error: {1}".format(vm_name, error.message)

--- a/appscale/tools/agents/azure_agent.py
+++ b/appscale/tools/agents/azure_agent.py
@@ -1491,7 +1491,7 @@ class AzureAgent(BaseAgent):
       return True
     return False
 
-  def run_and_return_exception(self, method, args):
+  def run_and_return_exception(self, method, *args):
     """ Runs a given method with args catching CloudError and returning it.
     Args:
       method: The method to call.

--- a/appscale/tools/agents/azure_agent.py
+++ b/appscale/tools/agents/azure_agent.py
@@ -1076,8 +1076,8 @@ class AzureAgent(BaseAgent):
         results[index] = ("VM still up",
             "{0} has not been successfully deleted".format(vm_info))
         return
-    AppScaleLogger.verbose("{0} has been successfully deleted".format(
-        instance_id, vmss_name), verbose)
+    AppScaleLogger.verbose("{0} has been successfully deleted".format(vm_info),
+                           verbose)
 
   def delete_virtual_machine(self, compute_client, parameters, vm_name):
     """ Deletes the virtual machine from the resource_group specified.

--- a/appscale/tools/agents/azure_agent.py
+++ b/appscale/tools/agents/azure_agent.py
@@ -565,7 +565,7 @@ class AzureAgent(BaseAgent):
       vm_list, error = self.run_and_return_exception(
           compute_client.virtual_machine_scale_set_vms.list,
           resource_group, vmss.name)
-      self.raise_if_error(error, "Error adding instances to existing"
+      self.raise_if_error(error, "Error adding instances to existing {}"
                           .format(scaleset_info))
       vm_list_results = self.convert_to_list(vm_list, raise_exception=True,
            err_msg="Error adding instances to existing {}".format(
@@ -1564,7 +1564,8 @@ class AzureAgent(BaseAgent):
       return True
     return False
 
-  def run_and_return_exception(self, method, *args):
+  @classmethod
+  def run_and_return_exception(cls, method, *args):
     """ Runs a given method with args catching CloudError and returning it.
     Args:
       method: The method to call.
@@ -1578,7 +1579,8 @@ class AzureAgent(BaseAgent):
     except CloudError as exception:
       return (None, exception)
 
-  def convert_to_list(self, page_iterator, raise_exception=False, err_msg=""):
+  @classmethod
+  def convert_to_list(cls, page_iterator, raise_exception=False, err_msg=""):
     """ Gets the given properties of an object and returns it in a
     dictionary. Either raises or returns an exception based on
     'raise_exception'.
@@ -1604,7 +1606,8 @@ class AzureAgent(BaseAgent):
         raise AgentRuntimeException("{} : {}".format(err_msg, error.message))
       return (None, error)
 
-  def raise_if_error(self, error, message):
+  @classmethod
+  def raise_if_error(cls, error, message):
     """Raises an AgentRuntimeException with the given message if error is not
     None.
 

--- a/appscale/tools/agents/azure_agent.py
+++ b/appscale/tools/agents/azure_agent.py
@@ -266,41 +266,93 @@ class AzureAgent(BaseAgent):
     private_ips = []
     instance_ids = []
 
-    public_ip_addresses = network_client.public_ip_addresses.list(resource_group)
-    for public_ip in public_ip_addresses:
-      public_ips.append(public_ip.ip_address)
+    public_ip_addresses, error = self.run_and_return_exception(
+        network_client.public_ip_addresses.list, resource_group)
+    self.raise_if_error(error, "Error calling describe instances")
 
-    network_interfaces = network_client.network_interfaces.list(resource_group)
-    for network_interface in network_interfaces:
-      for ip_config in network_interface.ip_configurations:
-        private_ips.append(ip_config.private_ip_address)
+    public_ips_results = self.get_properties(
+        public_ip_addresses, ['ip_address'], raise_exception=True,
+        err_msg="Error calling describe instances")
 
-    virtual_machines = compute_client.virtual_machines.list(resource_group)
-    for vm in virtual_machines:
-      instance_ids.append(vm.name)
+    public_ips = [x['ip_address'] for x in public_ips_results]
 
-    vmss_list = compute_client.virtual_machine_scale_sets.list(resource_group)
-    for vmss in vmss_list:
-      vm_list = compute_client.virtual_machine_scale_set_vms.list(resource_group,
-                                                                  vmss.name)
-      for vm in vm_list:
-        network_interface_list = network_client.network_interfaces. \
-          list_virtual_machine_scale_set_vm_network_interfaces(resource_group,
-                                                               vmss.name,
-                                                               vm.instance_id)
+    network_interfaces, error = self.run_and_return_exception(
+        network_client.network_interfaces.list, resource_group)
+    self.raise_if_error(error, "Error calling describe instances")
+
+    network_interfaces_results = self.get_properties(
+        network_interfaces, ['ip_configurations'], raise_exception=True,
+        err_msg="Error calling describe instances")
+
+    for network_interface in network_interfaces_results:
+      ip_config_results = self.get_properties(
+          network_interface['ip_configurations'], ['private_ip_address'],
+          raise_exception=True, err_msg="Error calling describe instances")
+
+      private_ips = [x['private_ip_address'] for x in ip_config_results]
+
+    virtual_machines, error = self.run_and_return_exception(
+        compute_client.virtual_machines.list, resource_group)
+    self.raise_if_error(error, "Error calling describe instances")
+
+    names = self.get_properties(virtual_machines, ['name'],
+        raise_exception=True, err_msg="Error calling describe instances")
+
+    instance_ids = [x['name'] for x in names]
+
+    vmss_list, error = self.run_and_return_exception(
+        compute_client.virtual_machine_scale_sets.list,
+        resource_group)
+    self.raise_if_error(error, "Error getting list of Scale Sets")
+
+    vmss_names = self.get_properties(vmss_list, ['name'],
+        raise_exception=True, err_msg="Error getting list of Scale Sets")
+
+    for scaleset_info_dict in vmss_names:
+      vmss_name = scaleset_info_dict['name']
+      vm_list, error = self.run_and_return_exception(
+          compute_client.virtual_machine_scale_set_vms.list,
+          resource_group, vmss_name)
+      self.raise_if_error(error, "Error getting list of vms in Scale Set "
+                                 "{}".format(vmss_name))
+
+      vm_list_results = self.get_properties(
+          vm_list, ['name', 'instance_id'], raise_exception=True,
+          err_msg="Error getting list of vms in Scale Set {}".format(vmss_name))
+      for vm_list_result in vm_list_results:
+        vm_instance_id = vm_list_result['instance_id']
+
+        network_interface_list, error = \
+          self.run_and_return_exception(network_client.network_interfaces.\
+              list_virtual_machine_scale_set_vm_network_interfaces,
+              resource_group, vmss_name, vm_instance_id)
+        self.raise_if_error(error, "Error getting list of network "
+            "interfaces in Scale Set {} for vm {}".format(
+            vmss_name, vm_instance_id))
+
         ip_config_private_ip = None
-        for network_interface in network_interface_list:
-          for ip_config in network_interface.ip_configurations:
-            ip_config_private_ip = ip_config.private_ip_address
-            break
+        network_interface_ip_config_results = self.get_properties(
+            network_interface_list, ['ip_configurations'],
+            raise_exception=True,
+            err_msg="Error getting private ip for VM {}".format(vm_instance_id))
 
+        for network_interface_result in network_interface_ip_config_results:
+          try:
+            for ip_config in network_interface_result['ip_configurations']:
+              ip_config_private_ip = ip_config.private_ip_address
+              break
+          except CloudError:
+            raise AgentRuntimeException('Error getting private ip address for '
+                'vm {} in Scale Set {}: {}'.format(vm_instance_id, vmss_name,
+                error.message))
           if ip_config_private_ip:
             break
 
         if ip_config_private_ip:
+          vm_name = vm_list_result['name']
           public_ips.append(ip_config_private_ip)
           private_ips.append(ip_config_private_ip)
-          instance_ids.append(vm.name)
+          instance_ids.append(vm_name)
 
     return public_ips, private_ips, instance_ids
 
@@ -451,12 +503,17 @@ class AzureAgent(BaseAgent):
 
     # Sleep until an IP address gets associated with the VM.
     while True:
-      public_ip_address = network_client.public_ip_addresses.get(resource_group,
-                                                                 vm_network_name)
-      if public_ip_address.ip_address:
-        AppScaleLogger.log('Azure load balancer VM is available at {}'.
-                           format(public_ip_address.ip_address))
-        break
+      public_ip_address, error = self.run_and_return_exception(
+        network_client.public_ip_addresses.get, resource_group, vm_network_name)
+      self.raise_if_error(error, "Failed to check if Public IP existed")
+      try:
+        if public_ip_address.ip_address:
+          AppScaleLogger.log('Azure load balancer VM is available at {}'.
+                             format(public_ip_address.ip_address))
+          break
+      except CloudError as error:
+        return "There was a problem creating the Virtual Machine due to the " \
+               "error: {0}".format(error.message)
       AppScaleLogger.verbose("Waiting {} second(s) for IP address to be "
                              "available".format(self.SLEEP_TIME), verbose)
       time.sleep(self.SLEEP_TIME)
@@ -508,31 +565,34 @@ class AzureAgent(BaseAgent):
     vmss_list, error = self.run_and_return_exception(
         compute_client.virtual_machine_scale_sets.list,
         resource_group)
-    if error:
-      # This method is not run in a thread so we can directly raise the
-      # exception.
-      raise AgentRuntimeException("Error adding instances to existing Scale "
-                                  "Set: {}".format(error.message))
+    self.raise_if_error(error, "Error adding instances to existing Scale Set")
+
+    vmss_list = self.get_properties(vmss_list, ['name'],
+        raise_exception=True,
+        err_msg="Error adding instances to existing Scale Set")
+
     for vmss in vmss_list:
+      vmss_name = vmss['name']
       vm_list, error = self.run_and_return_exception(
           compute_client.virtual_machine_scale_set_vms.list,
-          resource_group, vmss.name)
-      if error:
-        raise AgentRuntimeException("Error adding instances to Scale Set {}: "
-                                    "{}".format(vmss.name, error.message))
+          resource_group, vmss_name)
+      self.raise_if_error(error, "Error adding instances to existing Scale Set "
+                                 "{}".format(vmss_name))
       ss_instance_count = 0
-      for _ in vm_list:
-        ss_instance_count += 1
-
+      try:
+        for _ in vm_list:
+          ss_instance_count += 1
+      except CloudError as error:
+        raise AgentRuntimeException("Error adding instances to existing Scale "
+            "Set {}: {}".format(vmss_name, error.message))
       if ss_instance_count >= self.MAX_VMSS_CAPACITY:
         continue
 
       scaleset, error = self.run_and_return_exception(
           compute_client.virtual_machine_scale_sets.get,
-          resource_group, vmss.name)
-      if error:
-        raise AgentRuntimeException("Error adding instances to Scale Set {}: "
-                                    "{}".format(vmss.name, error.message))
+          resource_group, vmss_name)
+      self.raise_if_error(error, "Error adding instances to existing Scale Set "
+                                 "{}".format(vmss_name))
       ss_upgrade_policy = scaleset.upgrade_policy
       ss_location = scaleset.location
       ss_profile = scaleset.virtual_machine_profile
@@ -549,13 +609,12 @@ class AzureAgent(BaseAgent):
 
       create_update_response, error = self.run_and_return_exception(
         compute_client.virtual_machine_scale_sets.create_or_update,
-          resource_group, vmss.name, scaleset)
-      if error:
-        raise AgentRuntimeException("There was a problem while updating the "
-                                    "Scale Set {0} due to the error: "
-                                    "{1}".format(vmss.name, error.message))
+          resource_group, vmss_name, scaleset)
 
-      self.wait_for_ss_update(new_capacity, create_update_response, vmss.name)
+      self.raise_if_error(error, "There was a problem while updating the "
+                                 "Scale Set {0}".format(vmss_name))
+
+      self.wait_for_ss_update(new_capacity, create_update_response, vmss_name)
 
       newly_added = new_capacity - ss_instance_count
       num_instances_added += newly_added
@@ -765,9 +824,8 @@ class AzureAgent(BaseAgent):
     vmss_list, error = self.run_and_return_exception(
         compute_client.virtual_machine_scale_sets.list,
         resource_group)
-    if error:
-      raise AgentRuntimeException("Error terminating instances: {}".format(
-              error.message))
+    self.raise_if_error(error, "Error terminating instances")
+
     downscale = parameters['autoscale_agent']
 
     # Dictionary for nicely printing out exceptions.
@@ -780,19 +838,24 @@ class AzureAgent(BaseAgent):
       vmss_vm_delete_threads = []
       vmss_vm_delete_threads_results = [None for _ in range(len(instances_to_delete))]
       index = 0
-      for vmss in vmss_list:
+      vmss_list_results = self.get_properties(vmss_list, ['name'],
+          raise_exception=True, err_msg="Error terminating instances")
+
+      for vmss in vmss_list_results:
+        vmss_name = vmss['name']
         vm_list, error = self.run_and_return_exception(
             compute_client.virtual_machine_scale_set_vms.list,
-            resource_group, vmss.name)
-        if error:
-          raise AgentRuntimeException("Error downscaling: {}".format(
-              error.message))
-        for vm in vm_list:
-          if vm.name in instances_to_delete:
-            instances_to_delete.remove(vm.name)
+            resource_group, vmss_name)
+        self.raise_if_error(error, "Error terminating instances")
+        vm_list_results = self.get_properties(
+            vm_list, ['name', 'instance_id'], raise_exception=True,
+            err_msg="Error terminating instances")
+        for vm in vm_list_results:
+          if vm['name'] in instances_to_delete:
+            instances_to_delete.remove(vm['name'])
             thread = threading.Thread(target=self.delete_vmss_instance,
                                       args=(compute_client, parameters,
-                                            vmss.name, vm.instance_id,
+                                            vmss_name, vm['instance_id'],
                                             vmss_vm_delete_threads, index))
             index += 1
             thread.start()
@@ -816,17 +879,19 @@ class AzureAgent(BaseAgent):
       vmss_delete_threads = []
       vmss_delete_threads_results = []
       index = 0
-      for vmss in vmss_list:
+      vmss_list_results = self.get_properties(vmss_list, ['name'],
+          raise_exception=True, err_msg="Error terminating instances")
+      for vmss in vmss_list_results:
+        vmss_name = vmss['name']
         vm_list, error = self.run_and_return_exception(
             compute_client.virtual_machine_scale_set_vms.list,
-            resource_group, vmss.name)
-        if error:
-          raise AgentRuntimeException("Error downscaling: {}".format(
-              error.message))
+            resource_group, vmss_name)
+        self.raise_if_error(error, "Error terminating instances")
+
         if not any(True for _ in vm_list):
           thread = threading.Thread(
             target=self.delete_virtual_machine_scale_set, args=(
-              compute_client, parameters, vmss.name,
+              compute_client, parameters, vmss_name,
               vmss_delete_threads_results, index))
           index += 1
           thread.start()
@@ -853,17 +918,23 @@ class AzureAgent(BaseAgent):
     vmss_delete_threads = []
     vmss_delete_threads_results = []
     index = 0
-    for vmss in vmss_list:
+    vmss_list_results = self.get_properties(vmss_list, ['name'],
+        raise_exception=True, err_msg="Error terminating instances")
+
+    for vmss in vmss_list_results:
+      vmss_name = vmss['name']
       vm_list, error = self.run_and_return_exception(
           compute_client.virtual_machine_scale_set_vms.list,
-          resource_group, vmss.name)
-      if error:
-        raise AgentRuntimeException("Error terminating instances: {}".format(
-            error.message))
-      for vm in vm_list:
-        delete_ss_instances.append(vm.name)
+          resource_group, vmss_name)
+      self.raise_if_error(error, "Error terminating instances")
+
+      vm_list_results = self.get_properties(vm_list, ['name'],
+          raise_exception=True, err_msg="Error terminating instances")
+
+      for vm in vm_list_results:
+        delete_ss_instances.append(vm['name'])
       thread = threading.Thread(target=self.delete_virtual_machine_scale_set,
-                                args=(compute_client, parameters, vmss.name,
+                                args=(compute_client, parameters, vmss_name,
                                       vmss_delete_threads_results, index))
       index += 1
       thread.start()
@@ -974,8 +1045,13 @@ class AzureAgent(BaseAgent):
       return
 
     already_deleted = True
-    for vm in vm_list:
-      if instance_id == vm.name:
+    vm_list_results, error = self.get_properties(vm_list, ['name'])
+    if error:
+      results[index] = (error.message,
+                        "There was a problem while deleting {0}".format(
+                          vm_info))
+    for vm in vm_list_results:
+      if instance_id == vm['name']:
         already_deleted = False
         break
     if already_deleted:
@@ -1003,8 +1079,13 @@ class AzureAgent(BaseAgent):
       results[index] = (error.message,
           "There was a problem while deleting {0}".format(vm_info))
       return
-    for vm in vm_list:
-      if instance_id == vm.name:
+    vm_list_results, error = self.get_properties(vm_list, ['name'])
+    if error:
+      results[index] = (error.message,
+                        "There was a problem while deleting {0}".format(
+                          vm_info))
+    for vm in vm_list_results:
+      if instance_id == vm['name']:
         results[index] = ("VM still up",
             "{0} has not been successfully deleted".format(vm_info))
         return
@@ -1029,8 +1110,14 @@ class AzureAgent(BaseAgent):
       return "There was a problem while deleting the Virtual Machine {0} due " \
              "to the error: {1}".format(vm_name, error.message)
     already_deleted = True
-    for vm in virtual_machines:
-      if vm_name == vm.name:
+    virtual_machines_result, error = self.get_properties(virtual_machines,
+                                                         ['name'])
+
+    if error:
+      return "There was a problem while checking the Virtual Machine {0} due " \
+             "to the error: {1}".format(vm_name, error.message)
+    for vm in virtual_machines_result:
+      if vm_name == vm['name']:
         already_deleted = False
         break
     if already_deleted:
@@ -1055,9 +1142,13 @@ class AzureAgent(BaseAgent):
     if error:
       return "There was a problem while deleting the Virtual Machine {0} due " \
              "to the error: {1}".format(vm_name, error.message)
-
-    for vm in virtual_machines:
-      if vm_name == vm.name:
+    virtual_machines_result, error = self.get_properties(virtual_machines,
+                                                         ['name'])
+    if error:
+      return "There was a problem while checking the Virtual Machine {0} due " \
+             "to the error: {1}".format(vm_name, error.message)
+    for vm in virtual_machines_result:
+      if vm_name == vm['name']:
         return "Virtual Machine {0} has not been successfully " \
                "deleted".format(vm_name)
 
@@ -1504,3 +1595,50 @@ class AzureAgent(BaseAgent):
       return (result, None)
     except CloudError as exception:
       return (None, exception)
+
+  def get_properties(self, objs, properties, raise_exception=False,
+                     err_msg=""):
+    """ Gets the given properties of an object and returns it in a
+    dictionary. Either raises or returns an exception based on
+    'raise_exception'.
+    Args:
+      objs: The objects to iterate through.
+      properties: The list of properties to get from each object.
+      raise_exception: If True, raise exception. Otherwise return exception.
+    Returns:
+      A tuple containing either (result, None) or (None, Exception). Where
+      result is a list of dictionaries with the property name mapped to the
+      value. If raise_exception is set to True then it will raise the
+      exception instead of returning it.
+    Raises:
+      AgentRuntimeException if raises_exception is True and a cloud error
+      occurs.
+    """
+    try:
+      result = []
+      for obj in objs:
+        property_results = {}
+        for property_name in properties:
+          property_results[property_name] = (getattr(obj, property_name))
+        result.append(property_results)
+      if raise_exception:
+        return result
+      return (result, None)
+    except CloudError as error:
+      if raise_exception:
+        raise AgentRuntimeException("{} : {}".format(err_msg, error.message))
+      return (None, error)
+
+  def raise_if_error(self, error, message):
+    """Raises an AgentRuntimeException with the given message if error is not
+    None.
+
+    Args:
+      error: An Exception containing a message, or None if there was no
+        exception.
+      message: The additional message to add to the error's message.
+    Raises:
+      AgentRuntimeException if error is not None.
+    """
+    if error:
+      raise AgentRuntimeException("{} : {}".format(message, error.message))

--- a/appscale/tools/agents/azure_agent.py
+++ b/appscale/tools/agents/azure_agent.py
@@ -842,7 +842,8 @@ class AzureAgent(BaseAgent):
             thread = threading.Thread(target=self.delete_vmss_instance,
                                       args=(compute_client, parameters,
                                             vmss.name, vm.instance_id,
-                                            vmss_vm_delete_threads, index))
+                                            vmss_vm_delete_threads_results,
+                                            index))
             index += 1
             thread.start()
             vmss_vm_delete_threads.append(thread)

--- a/appscale/tools/agents/azure_agent.py
+++ b/appscale/tools/agents/azure_agent.py
@@ -1037,7 +1037,7 @@ class AzureAgent(BaseAgent):
                           vm_info))
       return
     for vm in vm_list_results:
-      if instance_id == vm.name:
+      if instance_id == vm.instance_id:
         already_deleted = False
         break
     if already_deleted:
@@ -1072,7 +1072,7 @@ class AzureAgent(BaseAgent):
                           vm_info))
       return
     for vm in vm_list_results:
-      if instance_id == vm.name:
+      if instance_id == vm.instance_id:
         results[index] = ("VM still up",
             "{0} has not been successfully deleted".format(vm_info))
         return

--- a/appscale/tools/agents/base_agent.py
+++ b/appscale/tools/agents/base_agent.py
@@ -207,6 +207,22 @@ class BaseAgent:
     raise NotImplementedError
 
 
+  def attach_disk(self, parameters, disk_name):
+    """ Acquires a previously created persistent disk and attaches it to this
+    machine.
+
+    The disk is not guaranteed to be formatted, nor is it mounted.
+
+    Args:
+      parameters: A dict containing the parameters necessary to communicate
+        with the underlying cloud infrastructure.
+      disk_name: A str naming the persistent disk to attach to this machine.
+    Returns:
+      The location on the local filesystem where the disk was attached to.
+    """
+    raise NotImplementedError
+
+
   def has_parameter(self, param, params):
     """Checks whether the parameter is present in the params dict.
 


### PR DESCRIPTION
This branch is a result of issues we have noticed with autoscaling in Azure on master. It attempts to cover the following cases:

- Failure to create instances due to reaching quota or other issue
- Failure to delete instances and confirmation of that failure
- Failures caused by paging through Azure Resources where each is a request and we hit the request limit.

`run_and_return_exception`, `raise_if_error`, and `convert_to_list` are meant to address these issues so that we can capture the `CloudError` that is thrown and return it if we're running within a thread or raise it if we are not running within a thread. Any errors captured in threads are raised after the joins so that the caller can handle the `AgentRuntimeException`

This branch requires a change on the appscale side as well so that the InfrastructureManager can handle the `AgentRuntimeException` and also base_agent is modified here so it could be removed to remove confusion about that exception. I'm working on unit tests for the appscale side so that will be up shortly.

I'd like to get reviews before posting the demo in case I have to rerun it but I have a demo ready.