### PR TITLE
Allow the user to deploy a service yaml file

### DIFF
--- a/appscale/tools/admin_api/version.py
+++ b/appscale/tools/admin_api/version.py
@@ -300,28 +300,3 @@ class Version(object):
         contents = config_file.read()
 
       return Version.from_contents(contents, file_name)
-
-  @staticmethod
-  def from_source(source_location):
-    """ Constructs a Version from a path.
-
-    Args:
-      source_location: A string specifying the location to a directory, tarball,
-        or zip file containing a config file.
-    Returns:
-      A Version object.
-    Raises:
-      AppengineConfigException if the config is invalid or missing.
-    """
-    if os.path.isdir(source_location):
-      return Version.from_directory(source_location)
-
-    if source_location.endswith('.tar.gz'):
-      return Version.from_tar_gz(source_location)
-
-    if source_location.endswith('.zip'):
-      return Version.from_zip(source_location)
-
-    raise AppEngineConfigException(
-      'Invalid source location: {}. Please specify a directory, a tar.gz file, '
-      'or a zip file.'.format(source_location))

--- a/appscale/tools/appscale.py
+++ b/appscale/tools/appscale.py
@@ -543,8 +543,8 @@ Available commands:
     # appscale-upload-app will do that for us.
     options = ParseArgs(command, "appscale-upload-app").args
     login_host, http_port = AppScaleTools.upload_app(options)
-    AppScaleTools.update_cron(options.file, options.keyname)
-    AppScaleTools.update_queues(options.file, options.keyname)
+    AppScaleTools.update_cron(options.file, options.keyname, options.project)
+    AppScaleTools.update_queues(options.file, options.keyname, options.project)
     return login_host, http_port
 
 

--- a/appscale/tools/appscale_tools.py
+++ b/appscale/tools/appscale_tools.py
@@ -943,19 +943,20 @@ class AppScaleTools(object):
       file_location = LocalState.extract_tgz_app_to_dir(options.file,
         options.verbose)
       created_dir = True
+      version = Version.from_tar_gz(options.file)
     elif cls.ZIP_REGEX.search(options.file):
       file_location = LocalState.extract_zip_app_to_dir(options.file,
         options.verbose)
       created_dir = True
+      version = Version.from_zip(options.file)
     elif os.path.isdir(options.file):
       file_location = options.file
       created_dir = False
+      version = Version.from_directory(options.file)
     else:
       raise AppEngineConfigException('{0} is not a tar.gz file, a zip file, ' \
         'or a directory. Please try uploading either a tar.gz file, a zip ' \
         'file, or a directory.'.format(options.file))
-
-    version = Version.from_source(options.file)
 
     if options.project:
       if version.runtime == 'java':

--- a/appscale/tools/appscale_tools.py
+++ b/appscale/tools/appscale_tools.py
@@ -939,6 +939,7 @@ class AppScaleTools(object):
       A tuple containing the host and port where the application is serving
         traffic from.
     """
+    custom_service_yaml = None
     if cls.TAR_GZ_REGEX.search(options.file):
       file_location = LocalState.extract_tgz_app_to_dir(options.file,
         options.verbose)
@@ -953,6 +954,11 @@ class AppScaleTools(object):
       file_location = options.file
       created_dir = False
       version = Version.from_directory(options.file)
+    elif options.file.endswith('.yaml'):
+      file_location = os.path.dirname(options.file)
+      created_dir = False
+      version = Version.from_yaml_file(options.file)
+      custom_service_yaml = options.file
     else:
       raise AppEngineConfigException('{0} is not a tar.gz file, a zip file, ' \
         'or a directory. Please try uploading either a tar.gz file, a zip ' \
@@ -993,8 +999,9 @@ class AppScaleTools(object):
     secret_key = LocalState.get_secret_key(options.keyname)
     admin_client = AdminClient(login_host, secret_key)
 
-    remote_file_path = RemoteHelper.copy_app_to_host(file_location,
-      version.project_id, options.keyname, options.verbose, extras)
+    remote_file_path = RemoteHelper.copy_app_to_host(
+      file_location, version.project_id, options.keyname, options.verbose,
+      extras, custom_service_yaml)
 
     AppScaleLogger.log(
       'Deploying service {} for {}'.format(version.service_id,

--- a/appscale/tools/remote_helper.py
+++ b/appscale/tools/remote_helper.py
@@ -1085,7 +1085,8 @@ class RemoteHelper(object):
 
 
   @classmethod
-  def copy_app_to_host(cls, app_location, app_id, keyname, is_verbose, extras=None):
+  def copy_app_to_host(cls, app_location, app_id, keyname, is_verbose,
+                       extras=None, custom_service_yaml=None):
     """Copies the given application to a machine running the Login service
     within an AppScale deployment.
 
@@ -1098,6 +1099,8 @@ class RemoteHelper(object):
       is_verbose: A bool that indicates if we should print the commands we exec
         to copy the app to the remote host to stdout.
       extras: A dictionary containing a list of files to include in the upload.
+      custom_service_yaml: A string specifying the location of the service
+        yaml being deployed.
 
     Returns:
       A str corresponding to the location on the remote filesystem where the
@@ -1123,9 +1126,15 @@ class RemoteHelper(object):
       app_files.update(extras)
 
     with tarfile.open(local_tarred_app, 'w:gz') as app_tar:
-      for tarball_path in app_files:
-        local_path = app_files[tarball_path]
+      for tarball_path, local_path in app_files.items():
+        # Replace app.yaml with the service yaml being deployed.
+        if custom_service_yaml and os.path.normpath(tarball_path) == 'app.yaml':
+          continue
+
         app_tar.add(local_path, tarball_path)
+
+      if custom_service_yaml:
+        app_tar.add(custom_service_yaml, 'app.yaml')
 
     AppScaleLogger.log("Copying over application")
     remote_app_tar = "{0}/{1}.tar.gz".format(cls.REMOTE_APP_DIR, app_id)

--- a/test/test_appscale_upload_app.py
+++ b/test/test_appscale_upload_app.py
@@ -260,7 +260,7 @@ class TestAppScaleUploadApp(unittest.TestCase):
       and_return(login_host)
     flexmock(LocalState).should_receive('get_secret_key').and_return(secret)
     flexmock(RemoteHelper).should_receive('copy_app_to_host').\
-      with_args(extracted_dir, app_id, self.keyname, False, {}).\
+      with_args(extracted_dir, app_id, self.keyname, False, {}, None).\
       and_return(source_path)
     flexmock(AdminClient).should_receive('create_version').\
       and_return(operation_id)

--- a/test/test_appscale_upload_app.py
+++ b/test/test_appscale_upload_app.py
@@ -254,7 +254,7 @@ class TestAppScaleUploadApp(unittest.TestCase):
 
     flexmock(LocalState).should_receive('extract_tgz_app_to_dir').\
       and_return('/tmp/{}'.format(app_id))
-    flexmock(Version).should_receive('from_source').and_return(version)
+    flexmock(Version).should_receive('from_tar_gz').and_return(version)
     flexmock(AppEngineHelper).should_receive('validate_app_id')
     flexmock(LocalState).should_receive('get_login_host').\
       and_return(login_host)
@@ -281,7 +281,7 @@ class TestAppScaleUploadApp(unittest.TestCase):
     # An application with the PHP runtime should be deployed successfully.
     version = Version('php')
     version.project_id = app_id
-    flexmock(Version).should_receive('from_source').and_return(version)
+    flexmock(Version).should_receive('from_tar_gz').and_return(version)
     flexmock(AdminClient).should_receive('create_version').\
       and_return(operation_id)
     given_host, given_port = AppScaleTools.upload_app(options)


### PR DESCRIPTION
In the uploaded tarball, this writes the service yaml to 'app.yaml', allowing the SDK to run just that service.

Resolves #692
Resolves #693 