### PR TITLE
One appserver running for Dashboard is enough to say "Ok" 

### DIFF
--- a/appscale/tools/appscale_tools.py
+++ b/appscale/tools/appscale_tools.py
@@ -267,7 +267,7 @@ class AppScaleTools(object):
     dashboard = next(
       (service for service in services
        if service.http == RemoteHelper.APP_DASHBOARD_PORT), None)
-    if dashboard and dashboard.appservers > 1:
+    if dashboard and dashboard.appservers >= 1:
       AppScaleLogger.success(
         "\nView more about your AppScale deployment at http://{}:{}/status"
         .format(login_host, RemoteHelper.APP_DASHBOARD_PORT)


### PR DESCRIPTION
Now `appscale status` reports gray text:
`As soon as AppScale Dashboard is started you can visit it at http://192.168.103.167:1080/status and see more about your deployment`
if there is only one appserver running for dashboard.

With this PR `appscale status` reports green text:
`View more about your AppScale deployment at http://192.168.103.167:1080/status`
in the same situation.

Resolves https://github.com/AppScale/appscale/issues/2782  (I mistakenly created the issue in appscale repo)