### PR TITLE
Limit Pip version

### DIFF
--- a/debian/appscale_build.sh
+++ b/debian/appscale_build.sh
@@ -20,12 +20,12 @@ fi
 # Some dependencies require a newer Pip than the repositories provide.
 case ${DIST} in
     trusty)
-        pip install -U pip
+        pip install -U 'pip<10'
         hash -r
         ;;
     jessie)
         # The system's pip does not allow updating itself.
-        easy_install pip
+        easy_install --upgrade 'pip<10.0.0b1'
         hash -r
         ;;
 esac


### PR DESCRIPTION
Starting with version 10, Pip does not allow updating packages that were installed with the distro's package manager.