### PR TITLE
Update index configuration after deploying version

### DIFF
--- a/appscale/tools/admin_api/client.py
+++ b/appscale/tools/admin_api/client.py
@@ -238,6 +238,33 @@ class AdminClient(object):
     raise AdminError(message)
 
   @retry(**RETRY_POLICY)
+  def update_indexes(self, project_id, indexes):
+    """ Updates the the project's index configuration.
+
+    Args:
+      project_id: A string specifying the project ID.
+      indexes: A dictionary containing index configuration details.
+    Raises:
+      AdminError if unable to update index configuration.
+    """
+    index_yaml = yaml.safe_dump(indexes, default_flow_style=False)
+    headers = {'AppScale-Secret': self.secret}
+    indexes_url = 'https://{}:{}/api/datastore/index/add?app_id={}'.format(
+      self.host, self.PORT, project_id)
+    response = requests.post(indexes_url, headers=headers, data=index_yaml,
+                             verify=False)
+
+    if response.status_code == 200:
+      return
+
+    try:
+      message = response.json()['error']['message']
+    except (ValueError, KeyError):
+      message = 'AdminServer returned: {}'.format(response.status_code)
+
+    raise AdminError(message)
+
+  @retry(**RETRY_POLICY)
   def update_queues(self, project_id, queues):
     """ Updates the the project's queue configuration.
 

--- a/appscale/tools/appscale.py
+++ b/appscale/tools/appscale.py
@@ -580,6 +580,7 @@ Available commands:
     # appscale-upload-app will do that for us.
     options = ParseArgs(command, "appscale-upload-app").args
     login_host, http_port = AppScaleTools.upload_app(options)
+    AppScaleTools.update_indexes(options.file, options.keyname)
     AppScaleTools.update_cron(options.file, options.keyname)
     AppScaleTools.update_queues(options.file, options.keyname)
     return login_host, http_port

--- a/test/test_appscale.py
+++ b/test/test_appscale.py
@@ -498,6 +498,7 @@ class TestAppScale(unittest.TestCase):
     flexmock(AppScaleTools)
     AppScaleTools.should_receive('upload_app').and_return(
       (fake_host, fake_port))
+    AppScaleTools.should_receive('update_indexes')
     AppScaleTools.should_receive('update_cron')
     AppScaleTools.should_receive('update_queues')
     app = '/bar/app'
@@ -567,6 +568,7 @@ class TestAppScale(unittest.TestCase):
     flexmock(AppScaleTools)
     AppScaleTools.should_receive('upload_app').and_return(
       (fake_host, fake_port))
+    AppScaleTools.should_receive('update_indexes')
     AppScaleTools.should_receive('update_cron')
     AppScaleTools.should_receive('update_queues')
     app = '/bar/app'


### PR DESCRIPTION
This allows the project's index configuration to be stored in ZooKeeper instead of being kept with the service source.