### PR TITLE
Warn about non appscale images for Azure

### DIFF
--- a/appscale/tools/agents/azure_agent.py
+++ b/appscale/tools/agents/azure_agent.py
@@ -1259,7 +1259,9 @@ class AzureAgent(BaseAgent):
     try:
       image = compute_client.virtual_machine_images.get(
           compatible_zone, publisher, offer, sku, version)
-
+      if not image.plan:
+        AppScaleLogger.warn("It is not recommended to use a non-AppScale image")
+        return
       market_place_client = MarketplaceOrderingAgreements(credentials,
                                                           subscription_id)
       term = market_place_client.marketplace_agreements.get(


### PR DESCRIPTION
AppScale images currently have a `plan` attribute. Unfortunately for our release process we need to let it slide if the marketplace image does not since `Canonical:UbuntuServer:16.04.0-LTS:latest` does not have a `plan` attribute

demo is build starting instance:
https://ocd.appscale.com:8080/job/Create-Azure-Image/388
https://ocd.appscale.com:8080/job/Create-Azure-Image/389