### PR TITLE
EC2 infrastructure agent disk device / warning

### DIFF
--- a/appscale/tools/agents/ec2_agent.py
+++ b/appscale/tools/agents/ec2_agent.py
@@ -696,6 +696,8 @@ class EC2Agent(BaseAgent):
     # get attached to.
     if glob.glob("/dev/xvd*"):
       mount_point = '/dev/xvdc'
+    elif glob.glob("/dev/vd*"):
+      mount_point = '/dev/vdc'
     else:
       mount_point = '/dev/sdc'
 
@@ -728,7 +730,7 @@ class EC2Agent(BaseAgent):
     """
     try:
       volumes = conn.get_all_volumes(filters={'attachment.instance-id':
-                                                instance_id})
+                                              instance_id})
       for volume in volumes:
         if volume.id == disk_name:
           return True
@@ -754,7 +756,7 @@ class EC2Agent(BaseAgent):
     """
     conn = self.open_connection(parameters)
     try:
-      conn.detach_volume(disk_name, instance_id, device='/dev/sdc')
+      conn.detach_volume(disk_name, instance_id)
       return True
     except boto.exception.EC2ResponseError:
       AppScaleLogger.log("Could not detach volume with name {0}".format(

--- a/appscale/tools/agents/euca_agent.py
+++ b/appscale/tools/agents/euca_agent.py
@@ -54,7 +54,7 @@ class EucalyptusAgent(EC2Agent):
       self.handle_failure('Unknown scheme in EC2_URL: ' + result.scheme)
       return None
 
-    if parameters.get('IS_VERBOSE', None):
+    if parameters.get(self.PARAM_VERBOSE, False):
       debug_level = 2  # extremely verbose
     else:
       debug_level = 0  # the silent treatment

--- a/appscale/tools/agents/euca_agent.py
+++ b/appscale/tools/agents/euca_agent.py
@@ -54,7 +54,7 @@ class EucalyptusAgent(EC2Agent):
       self.handle_failure('Unknown scheme in EC2_URL: ' + result.scheme)
       return None
 
-    if parameters['IS_VERBOSE']:
+    if parameters.get('IS_VERBOSE', None):
       debug_level = 2  # extremely verbose
     else:
       debug_level = 0  # the silent treatment

--- a/appscale/tools/appscale_tools.py
+++ b/appscale/tools/appscale_tools.py
@@ -740,8 +740,11 @@ class AppScaleTools(object):
     """
     LocalState.make_appscale_directory()
     LocalState.ensure_appscale_isnt_running(options.keyname, options.force)
+    node_layout = NodeLayout(options)
+
     if options.infrastructure:
-      if not options.disks and not options.test and not options.force:
+      if (not options.test and not options.force and
+          not (options.disks or node_layout.are_disks_used())):
         LocalState.ensure_user_wants_to_run_without_disks()
 
     reduced_version = '.'.join(x for x in APPSCALE_VERSION.split('.')[:2])
@@ -750,8 +753,6 @@ class AppScaleTools(object):
     my_id = str(uuid.uuid4())
     AppScaleLogger.remote_log_tools_state(options, my_id, "started",
       APPSCALE_VERSION)
-
-    node_layout = NodeLayout(options)
 
     head_node = node_layout.head_node()
     # Start VMs in cloud via cloud agent.

--- a/appscale/tools/node_layout.py
+++ b/appscale/tools/node_layout.py
@@ -513,6 +513,19 @@ class NodeLayout():
         return node
     return None
 
+  def are_disks_used(self):
+    """ Searches through the nodes in this NodeLayout to see if any persistent
+    disks are being used.
+
+    Returns:
+      True if any persistent disks are used, and False otherwise.
+    """
+    disks = [node.disk for node in self.nodes]
+    for disk in disks:
+      if disk:
+        return True
+    return False
+
   def to_list(self):
     """ Converts all of the nodes (except the head node) to a format that can
     be easily JSON-dumped (a list of dicts).


### PR DESCRIPTION
Update the ec2 agent to allow for `/dev/vd*` devices and the euca agent to not require the `IS_VERBOSE` parameter. This allows use of `infrastructure : euca` with persistent disks.

The warning for not using persistent disks is no longer shown when disks are configured under `ips_layout`.