### PR TITLE
Remove a project's services on 'undeploy'

### DIFF
--- a/appscale/tools/admin_api/client.py
+++ b/appscale/tools/admin_api/client.py
@@ -174,34 +174,20 @@ class AdminClient(object):
     return operation_id
 
   @retry(**RETRY_POLICY)
-  def delete_project(self, project_id):
-    """ Deletes a project.
-
-    Args:
-      project_id: A string specifying the project ID.
-    Raises:
-      AdminError if the response is not 200.
-    """
-    url = 'https://{}:{}/v1/projects/{}'.format(self.host, self.PORT,
-                                                project_id)
-    headers = {'AppScale-Secret': self.secret}
-    response = requests.delete(url, headers=headers, verify=False)
-    if response.status_code != 200:
-      raise AdminError('Error asking Admin Server to delete project!')
-
-  @retry(**RETRY_POLICY)
-  def list_projects(self):
-    """ Lists projects.
+  def list_services(self, project_id):
+    """ Lists a project's services.
 
     Returns:
-      A list containing the projects of this deployment.
+      A list containing the project's service IDs.
     Raises:
       AdminError if the response is formatted incorrectly.
     """
-    url = 'https://{}:{}/v1/projects'.format(self.host, self.PORT)
+    url = 'https://{}:{}/v1/apps/{}/services'.format(
+      self.host, self.PORT, project_id)
     headers = {'AppScale-Secret': self.secret}
     response = requests.get(url, headers=headers, verify=False)
-    return self.extract_response(response)
+    return [service['id']
+            for service in self.extract_response(response)['services']]
 
   @retry(**RETRY_POLICY)
   def get_operation(self, project, operation_id):

--- a/appscale/tools/appscale_tools.py
+++ b/appscale/tools/appscale_tools.py
@@ -601,7 +601,7 @@ class AppScaleTools(object):
     """
     if not options.confirm:
       response = raw_input(
-        "Are you sure you want to stop this project's services? (y/N) ")
+        "Are you sure you want to delete this project's services? (y/N) ")
       if response.lower() not in ['y', 'yes']:
         raise AppScaleException("Cancelled application removal.")
 
@@ -610,7 +610,7 @@ class AppScaleTools(object):
     admin_client = AdminClient(login_host, secret)
 
     for service_id in admin_client.list_services(options.project_id):
-      AppScaleLogger.log('Stopping service: {}'.format(service_id))
+      AppScaleLogger.log('Deleting service: {}'.format(service_id))
       cls._remove_service(admin_client, options.project_id, service_id)
 
     AppScaleLogger.success('Done shutting down {}.'.format(options.project_id))

--- a/test/test_appscale_remove_app.py
+++ b/test/test_appscale_remove_app.py
@@ -60,9 +60,6 @@ class TestAppScaleRemoveApp(unittest.TestCase):
     builtins.should_receive('open').with_args(secret_key_location, 'r') \
       .and_return(fake_secret)
 
-    flexmock(AdminClient).should_receive('delete_project').\
-      and_raise(AdminError)
-
     # mock out reading the locations.json file, and slip in our own json
     flexmock(os.path)
     os.path.should_call('exists')  # set the fall-through
@@ -81,6 +78,8 @@ class TestAppScaleRemoveApp(unittest.TestCase):
       LocalState.get_locations_json_location(self.keyname), 'r') \
       .and_return(fake_nodes_json)
 
+    flexmock(AdminClient).should_receive('list_services').\
+      and_raise(AdminError)
     argv = [
       "--project-id", "blargapp",
       "--keyname", self.keyname
@@ -121,12 +120,12 @@ class TestAppScaleRemoveApp(unittest.TestCase):
       LocalState.get_locations_json_location(self.keyname), 'r') \
       .and_return(fake_nodes_json)
 
-    operation_id = 'operation-1'
-    flexmock(AdminClient).should_receive('delete_project').\
-      and_return(operation_id)
-    flexmock(AdminClient).should_receive('list_projects').\
-      and_return({'projects': []})
-
+    flexmock(AdminClient).should_receive('list_services').\
+      and_return(['default'])
+    flexmock(AdminClient).should_receive('delete_service').\
+      with_args('blargapp', 'default').and_return('op_id')
+    flexmock(AdminClient).should_receive('get_operation').\
+      with_args('blargapp', 'op_id').and_return({'done': True})
     argv = [
       "--project-id", "blargapp",
       "--keyname", self.keyname


### PR DESCRIPTION
Since the project delete operation is no longer supported, delete the project's services instead.

Resolves #727.