### PR TITLE
Fix index configuration parsing for Java apps

### DIFF
--- a/appscale/tools/appscale_tools.py
+++ b/appscale/tools/appscale_tools.py
@@ -1100,16 +1100,10 @@ class AppScaleTools(object):
     if project_id:
       version.project_id = project_id
 
-    index_config = fetch_function('index.yaml', source_location)
-    if index_config is None:
-      index_config = fetch_function('datastore-indexes.xml', source_location)
-      # If the source does not have an index configuration file, do nothing.
-      if index_config is None:
-        return
-
-      indexes = utils.indexes_from_xml(index_config)
-    else:
-      indexes = yaml.safe_load(index_config)
+    indexes = utils.get_indexes(source_location, fetch_function)
+    # If the source does not have an index configuration file, do nothing.
+    if indexes is None:
+      return
 
     AppScaleLogger.log('Updating indexes')
     login_host = LocalState.get_login_host(keyname)

--- a/appscale/tools/utils.py
+++ b/appscale/tools/utils.py
@@ -155,13 +155,12 @@ def indexes_from_xml(contents):
   Returns:
     A dictionary containing index configuration details.
   """
-  tree = ElementTree.fromstring(contents)
-  if len(tree) != 1 or tree[0].tag != 'datastore-indexes':
+  index_entries = ElementTree.fromstring(contents)
+  if index_entries.tag != 'datastore-indexes':
     raise BadConfigurationException(
       'datastore-indexes.xml should have a single root element named '
       'datastore-indexes')
 
-  index_entries = tree[0]
   indexes = {'indexes': []}
   for index_entry in index_entries:
     if index_entry.tag != 'datastore-index':

--- a/appscale/tools/utils.py
+++ b/appscale/tools/utils.py
@@ -3,6 +3,7 @@
 import errno
 import os
 import tarfile
+import yaml
 import zipfile
 from xml.etree import ElementTree
 
@@ -205,6 +206,28 @@ def indexes_from_xml(contents):
     indexes['indexes'].append(index)
 
   return indexes
+
+
+def get_indexes(source_location, fetch_function):
+  """ Retrieves a list of index definitions from a source's configuration.
+
+  Args:
+    source_location: A string specifying the location of the source code.
+    fetch_function: The function used to find a file within the source.
+  Returns:
+    A list of dictionaries containing index definition details or None.
+  """
+  index_config = fetch_function('index.yaml', source_location)
+  if index_config is not None:
+    return yaml.safe_load(index_config)
+
+  index_config = fetch_function('datastore-indexes.xml', source_location)
+  if index_config is not None:
+    return indexes_from_xml(index_config)
+
+  index_config = fetch_function('datastore-indexes-auto.xml', source_location)
+  if index_config is not None:
+    return indexes_from_xml(index_config)
 
 
 def queues_from_xml(contents):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,7 +1,7 @@
 import unittest
 
 from appscale.tools.custom_exceptions import BadConfigurationException
-from appscale.tools.utils import cron_from_xml
+from appscale.tools.utils import cron_from_xml, indexes_from_xml
 
 
 class TestUtils(unittest.TestCase):
@@ -52,3 +52,41 @@ class TestUtils(unittest.TestCase):
     """.strip()
     with self.assertRaises(BadConfigurationException):
       cron_from_xml(contents)
+
+  def test_indexes_from_xml(self):
+    contents = """
+    <?xml version="1.0" encoding="utf-8"?>
+    <datastore-indexes autoGenerate="true">
+        <datastore-index kind="Employee" ancestor="false">
+            <property name="lastName" direction="asc" />
+            <property name="hireDate" direction="desc" />
+        </datastore-index>
+        <datastore-index kind="Project" ancestor="false">
+            <property name="dueDate" direction="asc" />
+            <property name="cost" direction="desc" />
+        </datastore-index>
+    </datastore-indexes>
+    """.strip()
+
+    expected_config = {
+      'indexes': [
+        {'kind': 'Employee',
+         'ancestor': 'false',
+         'properties': [{'name': 'lastName', 'direction': 'asc'},
+                        {'name': 'hireDate', 'direction': 'desc'}]},
+        {'kind': 'Project',
+         'ancestor': 'false',
+         'properties': [{'name': 'dueDate', 'direction': 'asc'},
+                        {'name': 'cost', 'direction': 'desc'}]}
+      ]
+    }
+    self.assertDictEqual(indexes_from_xml(contents), expected_config)
+
+    contents = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <datastore-indexes>
+      <invalid-element></invalid-element>
+    </datastore-indexes>
+    """.strip()
+    with self.assertRaises(BadConfigurationException):
+      indexes_from_xml(contents)


### PR DESCRIPTION
Previously, the wrong element was being selected as the XML root.

This also adds the SDK-generated "datastore-indexes-auto.xml" as a fallback source for index configuration.