### PR TITLE
Update check for automatic and manual scaling in xml descriptor

### DIFF
--- a/appscale/tools/admin_api/version.py
+++ b/appscale/tools/admin_api/version.py
@@ -165,17 +165,17 @@ class Version(object):
 
     automatic_scaling = root.find(qname('automatic-scaling'))
     manual_scaling = root.find(qname('manual-scaling'))
-    if automatic_scaling and manual_scaling:
+    if automatic_scaling is not None and manual_scaling is not None:
       raise AppEngineConfigException(
         'Invalid appengine-web.xml: If "automatic-scaling" is defined, '
         '"manual-scaling" cannot be defined.')
-    elif manual_scaling:
+    elif manual_scaling is not None:
         try:
             version.manual_scaling = {
                 'instances': int(manual_scaling.findtext(qname('instances')))}
         except StandardError:
             raise AppEngineConfigException('Invalid app.yaml: manual_scaling invalid.')
-    elif automatic_scaling:
+    elif automatic_scaling is not None:
         try:
             version.automatic_scaling = {'standardSchedulerSettings': {
                 'minInstances': int(automatic_scaling.findtext(qname('min-instances'))),


### PR DESCRIPTION
Update `appengine-web.xml` validation checks for scaling elements. 

The tests for `automatic-scaling` and `manual-scaling` now check for `None`. Previously warnings such as the following were logged if using these xml scaling configuration elements:
```
/usr/local/lib/python2.7/dist-packages/appscale/tools/admin_api/version.py:168: FutureWarning: The behavior of this method will change in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
  if automatic_scaling and manual_scaling:
/usr/local/lib/python2.7/dist-packages/appscale/tools/admin_api/version.py:178: FutureWarning: The behavior of this method will change in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
  elif automatic_scaling:
```
This does not cause any functionality issues, but these warnings are logged on `appscale deploy`.