### PR TITLE
Whitelist additional acceptable instance types

### DIFF
--- a/appscale/tools/parse_args.py
+++ b/appscale/tools/parse_args.py
@@ -50,15 +50,21 @@ class ParseArgs(object):
   # limitation.
   ALLOWED_EC2_INSTANCE_TYPES = [
     # General Purpose Instances
+    "m1.medium", "m1.large", "m1.xlarge",
     "m3.medium", "m3.large", "m3.xlarge", "m3.2xlarge",
+    "m4.large", "m4.xlarge", "m4.2xlarge", "m4.4xlarge", "m4.10xlarge",
+    "m4.16xlarge",
+    "m5.large", "m5.xlarge", "m5.2xlarge", "m5.4xlarge", "m5.12xlarge",
 
     # Compute Optimized Instances
+    "c1.xlarge",
     "c3.large", "c3.xlarge", "c3.2xlarge", "c3.4xlarge", "c3.8xlarge",
 
     # Cluster Compute Instances
     "cc2.8xlarge",
 
     # High Memory Cluster Instances
+    "m2.xlarge", "m2.2xlarge", "m2.4xlarge",
     "cr1.8xlarge",
 
     # Cluster GPU Instances


### PR DESCRIPTION
This re-adds first-generation instances as well as a few newer-generation instances.