### PR TITLE
Include subnet and vpc IDs when setting parameters

### DIFF
--- a/appscale/tools/local_state.py
+++ b/appscale/tools/local_state.py
@@ -231,6 +231,8 @@ class LocalState(object):
         iaas_creds['project'] = options.project
         iaas_creds['gce_user'] = getpass.getuser()
       elif options.infrastructure in ['euca', 'ec2']:
+        iaas_creds['aws_subnet_id'] = options.aws_subnet_id
+        iaas_creds['aws_vpc_id'] = options.aws_vpc_id
         iaas_creds['EC2_ACCESS_KEY'] = options.EC2_ACCESS_KEY
         iaas_creds['EC2_SECRET_KEY'] = options.EC2_SECRET_KEY
         iaas_creds['EC2_URL'] = options.EC2_URL

--- a/test/test_local_state.py
+++ b/test/test_local_state.py
@@ -101,7 +101,8 @@ class TestLocalState(unittest.TestCase):
       clear_datastore=False, disks={'node-1' : 'vol-ABCDEFG'},
       zone='my-zone-1b', verbose=True, user_commands=[], flower_password="abc",
       default_max_appserver_memory=ParseArgs.DEFAULT_MAX_APPSERVER_MEMORY,
-      EC2_ACCESS_KEY='baz', EC2_SECRET_KEY='baz', EC2_URL='')
+      EC2_ACCESS_KEY='baz', EC2_SECRET_KEY='baz', EC2_URL='',
+      aws_subnet_id=None, aws_vpc_id=None)
     node_layout = NodeLayout({
       'table' : 'cassandra',
       'infrastructure' : "ec2",
@@ -136,7 +137,9 @@ class TestLocalState(unittest.TestCase):
       'default_max_appserver_memory' : str(ParseArgs.DEFAULT_MAX_APPSERVER_MEMORY),
       'EC2_ACCESS_KEY': 'baz',
       'EC2_SECRET_KEY': 'baz',
-      'EC2_URL': ''
+      'EC2_URL': '',
+      'aws_subnet_id': None,
+      'aws_vpc_id': None
     }
     actual = LocalState.generate_deployment_params(options, node_layout,
       {'max_spot_price':'1.23'})
@@ -153,7 +156,8 @@ class TestLocalState(unittest.TestCase):
       clear_datastore=False, disks={'node-1' : 'vol-ABCDEFG'},
       zone='my-zone-1b', verbose=True, user_commands=[], flower_password="abc",
       default_max_appserver_memory=ParseArgs.DEFAULT_MAX_APPSERVER_MEMORY,
-      EC2_ACCESS_KEY='baz', EC2_SECRET_KEY='baz', EC2_URL='')
+      EC2_ACCESS_KEY='baz', EC2_SECRET_KEY='baz', EC2_URL='',
+      aws_subnet_id=None, aws_vpc_id=None)
     node_layout = NodeLayout({
       'table': 'cassandra',
       'infrastructure': "ec2",
@@ -188,7 +192,9 @@ class TestLocalState(unittest.TestCase):
       'default_max_appserver_memory': str(ParseArgs.DEFAULT_MAX_APPSERVER_MEMORY),
       'EC2_ACCESS_KEY': 'baz',
       'EC2_SECRET_KEY': 'baz',
-      'EC2_URL': ''
+      'EC2_URL': '',
+      'aws_subnet_id': None,
+      'aws_vpc_id': None
     }
     actual = LocalState.generate_deployment_params(options, node_layout,
       {'max_spot_price': '1.23'})


### PR DESCRIPTION
This goes with https://github.com/AppScale/appscale/pull/3005.