### PR TITLE
Upgrade cloud fix

### DIFF
--- a/appscale/tools/appscale.py
+++ b/appscale/tools/appscale.py
@@ -925,4 +925,5 @@ Available commands:
     options.ips = yaml.safe_load(base64.b64decode(options.ips_layout))
     options.terminate = False
     options.clean = False
+    options.instance_type = contents_as_yaml.get('instance_type')
     AppScaleTools.upgrade(options)

--- a/appscale/tools/appscale_tools.py
+++ b/appscale/tools/appscale_tools.py
@@ -1226,6 +1226,9 @@ class AppScaleTools(object):
         passed in via the command-line interface.
     """
     node_layout = NodeLayout(options)
+    previous_node_list = node_layout.from_locations_json_list(
+        LocalState.get_local_nodes_info(options.keyname))
+    node_layout.nodes = previous_node_list
 
     latest_tools = APPSCALE_VERSION
     try:

--- a/appscale/tools/appscale_tools.py
+++ b/appscale/tools/appscale_tools.py
@@ -1226,8 +1226,8 @@ class AppScaleTools(object):
         passed in via the command-line interface.
     """
     node_layout = NodeLayout(options)
-    previous_node_list = node_layout.from_locations_json_list(
-        LocalState.get_local_nodes_info(options.keyname))
+    previous_ips = LocalState.get_local_nodes_info(options.keyname)
+    previous_node_list = node_layout.from_locations_json_list(previous_ips)
     node_layout.nodes = previous_node_list
 
     latest_tools = APPSCALE_VERSION


### PR DESCRIPTION
With a multi-node cloud deployment an upgrade will fail since it will use "node-0", "node-1", etc as the public ips.

The instance_type option is added from the AppScalefile since nodes are determined to be equal if they have the same roles and instance types.