### PR TITLE
Log warning on deploy for unsupported queue rate options

### DIFF
--- a/appscale/tools/appscale_tools.py
+++ b/appscale/tools/appscale_tools.py
@@ -1213,6 +1213,13 @@ class AppScaleTools(object):
       queues = yaml.safe_load(queue_config)
 
     AppScaleLogger.log('Updating queues')
+
+    for queue in queues.get('queue', []):
+      if 'bucket_size' in queue or 'max_concurrent_requests' in queue:
+        AppScaleLogger.warn('Queue configuration uses unsupported rate options'
+                            ' (bucket size or max concurrent requests)')
+        break
+
     login_host = LocalState.get_login_host(keyname)
     secret_key = LocalState.get_secret_key(keyname)
     admin_client = AdminClient(login_host, secret_key)


### PR DESCRIPTION
Log a warning when an application is deployed using unsupported rate options.