### PR TITLE
Require a keyring version with python 2 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
     'google-api-python-client==1.5.4',
     'haikunator',
     'httplib2',
+    'keyring<19.0.0',
     'msrestazure==0.4.34',
     'oauth2client==4.0.0',
     'pyOpenSSL>=18.0.0',


### PR DESCRIPTION
Keyring v19 dropped support for Python 2.7 - 3.4, an explicit dependency is added to ensure a compatible version is installed.