### PR TITLE
Bump version to 3.7.1

### DIFF
--- a/appscale/tools/local_state.py
+++ b/appscale/tools/local_state.py
@@ -31,7 +31,7 @@ from custom_exceptions import ShellException
 
 
 # The version of the AppScale Tools we're running on.
-APPSCALE_VERSION = "3.7.0"
+APPSCALE_VERSION = "3.7.1"
 
 
 class LocalState(object):

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ http://www.appscale.com
 
 setup(
   name='appscale-tools',
-  version='3.7.0',
+  version='3.7.1',
   description='A set of command-line tools for interacting with AppScale',
   long_description=long_description,
   author='AppScale Systems, Inc.',


### PR DESCRIPTION
Although there are no changes in appscale-tools, bump version to 3.7.1 to make build process easier.