### PR TITLE
Use systemd instead of monit for service management

### DIFF
--- a/appscale/tools/appscale_tools.py
+++ b/appscale/tools/appscale_tools.py
@@ -449,7 +449,6 @@ class AppScaleTools(object):
       {'remote': '/var/log/appscale'},
       {'remote': '/var/log/haproxy.log*'},
       {'remote': '/var/log/kern.log*'},
-      {'remote': '/var/log/monit.log*'},
       {'remote': '/var/log/nginx'},
       {'remote': '/var/log/rabbitmq/*', 'local': 'rabbitmq'},
       {'remote': '/var/log/syslog*'},

--- a/appscale/tools/remote_helper.py
+++ b/appscale/tools/remote_helper.py
@@ -769,17 +769,8 @@ class RemoteHelper(object):
     """
     AppScaleLogger.log("Starting AppController at {0}".format(host))
 
-    # Remove any previous state. TODO: Don't do this with the tools.
-    cls.ssh(host, keyname,
-      'rm -rf {}/appcontroller-state.json'.format(cls.CONFIG_DIR), is_verbose)
-
-    # Remove any monit configuration files from previous AppScale deployments.
-    cls.ssh(host, keyname, 'rm -rf /etc/monit/conf.d/appscale-*.cfg', is_verbose)
-
-    cls.ssh(host, keyname, 'service monit start', is_verbose)
-
     # Start the AppController.
-    cls.ssh(host, keyname, 'service appscale-controller start', is_verbose)
+    cls.ssh(host, keyname, 'systemctl start appscale-controller', is_verbose)
 
     AppScaleLogger.log("Please wait for the AppController to finish " + \
       "pre-processing tasks.")

--- a/test/test_appscale_run_instances.py
+++ b/test/test_appscale_run_instances.py
@@ -331,25 +331,8 @@ EC2_SECRET_KEY: 'baz'
       .with_args(re.compile('^openssl'),False,stdin=None)\
       .and_return()
 
-    # mock out removing the old json file
-    self.local_state.should_receive('shell')\
-      .with_args(re.compile('^ssh'),False,5,stdin=re.compile('rm -rf'))\
-      .and_return()
-
-    # assume that we started monit fine
-    self.local_state.should_receive('shell')\
-      .with_args(re.compile('^ssh'),False,5,stdin=re.compile('monit'))\
-      .and_return()
-
     self.local_state.should_receive('shell').with_args(
-      re.compile('^ssh'), False, 5, stdin='service appscale-controller start')
-
-    self.local_state.should_receive('shell').\
-      with_args('ssh -i /root/.appscale/boobazblargfoo.key -o LogLevel=quiet '
-                '-o NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no '
-                '-o UserKnownHostsFile=/dev/null root@{} '.format(IP_1),
-                False, 5,
-                stdin='cp /root/appscale/AppController/scripts/appcontroller /etc/init.d/').and_return()
+      re.compile('^ssh'), False, 5, stdin='systemctl start appscale-controller')
 
     self.setup_socket_mocks(IP_1)
     self.setup_appcontroller_mocks(IP_1, IP_1)
@@ -509,43 +492,14 @@ EC2_SECRET_KEY: 'baz'
       with_args(re.compile('scp .*{0}'.format(self.keyname)), False, 5).\
       and_return()
 
-    self.local_state.should_receive('shell').\
-      with_args('ssh -i /root/.appscale/bookey.key -o LogLevel=quiet -o '
-                'NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no '
-                '-o UserKnownHostsFile=/dev/null root@public1 ',
-                False, 5,
-                stdin='cp /root/appscale/AppController/scripts/appcontroller '
-                      '/etc/init.d/').\
-      and_return()
-
-    self.local_state.should_receive('shell').\
-      with_args('ssh -i /root/.appscale/boobazblargfoo.key -o LogLevel=quiet '
-                '-o NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no '
-                '-o UserKnownHostsFile=/dev/null root@elastic-ip ',
-                False, 5,
-                stdin='cp /root/appscale/AppController/scripts/appcontroller '
-                      '/etc/init.d/').\
-      and_return()
-
-    self.local_state.should_receive('shell').\
-      with_args('ssh -i /root/.appscale/boobazblargfoo.key -o LogLevel=quiet '
-                '-o NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no '
-                '-o UserKnownHostsFile=/dev/null root@elastic-ip ',
-                False, 5, stdin='chmod +x /etc/init.d/appcontroller').\
-      and_return()
-
     self.setup_appscale_compatibility_mocks()
 
     # mock out generating the private key
     self.local_state.should_receive('shell').with_args(re.compile('openssl'),
       False, stdin=None)
 
-    # assume that we started monit fine
-    self.local_state.should_receive('shell').with_args(re.compile('ssh'),
-      False, 5, stdin=re.compile('monit'))
-
     self.local_state.should_receive('shell').with_args(
-      re.compile('^ssh'), False, 5, stdin='service appscale-controller start')
+      re.compile('^ssh'), False, 5, stdin='systemctl start appscale-controller')
 
     self.setup_socket_mocks('elastic-ip')
     self.setup_appcontroller_mocks('elastic-ip', 'private1')
@@ -702,12 +656,8 @@ EC2_SECRET_KEY: 'baz'
     self.local_state.should_receive('shell').with_args(re.compile('openssl'),
       False, stdin=None)
 
-    # assume that we started monit fine
-    self.local_state.should_receive('shell').with_args(re.compile('ssh'),
-      False, 5, stdin=re.compile('monit'))
-
     self.local_state.should_receive('shell').with_args(
-      re.compile('^ssh'), False, 5, stdin='service appscale-controller start')
+      re.compile('^ssh'), False, 5, stdin='systemctl start appscale-controller')
 
     self.setup_socket_mocks('public1')
     self.setup_appcontroller_mocks('public1', 'private1')
@@ -727,16 +677,6 @@ EC2_SECRET_KEY: 'baz'
     # same for the secret key
     self.local_state.should_receive('shell').with_args(re.compile('scp'),
       False, 5, stdin=re.compile('{0}.secret'.format(self.keyname)))
-
-    self.local_state.should_receive('shell').with_args('ssh -i /root/.appscale/boobazbargfoo.key -o LogLevel=quiet -o NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no -o UserKnownHostsFile=/dev/null root@public1 ', False, 5, stdin='cp /root/appscale/AppController/scripts/appcontroller /etc/init.d/').and_return()
-
-    self.local_state.should_receive('shell').with_args('ssh -i /root/.appscale/boobazblargfoo.key -o LogLevel=quiet -o NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no -o UserKnownHostsFile=/dev/null root@elastic-ip ', False, 5, stdin='cp /root/appscale/AppController/scripts/appcontroller /etc/init.d/').and_return()
-
-    self.local_state.should_receive('shell').with_args('ssh -i /root/.appscale/boobazblargfoo.key -o LogLevel=quiet -o NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no -o UserKnownHostsFile=/dev/null root@elastic-ip ', False, 5, stdin='chmod +x /etc/init.d/appcontroller').and_return()
-
-    self.local_state.should_receive('shell').with_args('ssh -i /root/.appscale/boobazblargfoo.key -o LogLevel=quiet -o NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no -o UserKnownHostsFile=/dev/null root@public1 ', False, 5, stdin='cp /root/appscale/AppController/scripts/appcontroller /etc/init.d/')
-
-    self.local_state.should_receive('shell').with_args('ssh -i /root/.appscale/boobazblargfoo.key -o LogLevel=quiet -o NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no -o UserKnownHostsFile=/dev/null root@public1 ', False, 5, stdin='chmod +x /etc/init.d/appcontroller').and_return()
 
     flexmock(RemoteHelper).should_receive('copy_deployment_credentials')
     flexmock(AppControllerClient)

--- a/test/test_appscale_run_instances.py
+++ b/test/test_appscale_run_instances.py
@@ -333,7 +333,7 @@ EC2_SECRET_KEY: 'baz'
       .and_return()
 
     self.local_state.should_receive('shell').with_args(
-      re.compile('^ssh'), False, 5, stdin='systemctl start appscale-controller')
+      re.compile('^ssh'), None, 5, stdin='systemctl start appscale-controller')
 
     self.setup_socket_mocks(IP_1)
     self.setup_appcontroller_mocks(IP_1, IP_1)
@@ -503,7 +503,7 @@ EC2_SECRET_KEY: 'baz'
       stdin=None)
 
     self.local_state.should_receive('shell').with_args(
-      re.compile('^ssh'), False, 5, stdin='systemctl start appscale-controller')
+      re.compile('^ssh'), None, 5, stdin='systemctl start appscale-controller')
 
     self.setup_socket_mocks('elastic-ip')
     self.setup_appcontroller_mocks('elastic-ip', 'private1')
@@ -664,7 +664,7 @@ EC2_SECRET_KEY: 'baz'
       None, stdin=None)
 
     self.local_state.should_receive('shell').with_args(
-      re.compile('^ssh'), False, 5, stdin='systemctl start appscale-controller')
+      re.compile('^ssh'), None, 5, stdin='systemctl start appscale-controller')
 
     self.setup_socket_mocks('public1')
     self.setup_appcontroller_mocks('public1', 'private1')
@@ -763,6 +763,9 @@ EC2_SECRET_KEY: 'baz'
     AppControllerClient.should_receive('set_admin_role').and_return('true')
     AppControllerClient.should_receive('get_property').\
       and_return({'login': IP_1})
+
+    flexmock(AppScaleLogger)
+    AppScaleLogger.should_receive('remote_log_tools_state').and_return()
 
     # don't use a 192.168.X.Y IP here, since sometimes we set our virtual
     # machines to boot with those addresses (and that can mess up our tests).

--- a/test/test_remote_helper.py
+++ b/test/test_remote_helper.py
@@ -359,20 +359,11 @@ class TestRemoteHelper(unittest.TestCase):
     RemoteHelper.copy_deployment_credentials('public1', options)
 
   def test_start_remote_appcontroller(self):
-    # mock out removing the old json file
     local_state = flexmock(LocalState)
-    local_state.should_receive('shell')\
-      .with_args(re.compile('^ssh'),False,5,stdin=re.compile('rm -rf'))\
-      .and_return()
-
-    # assume we started monit on public1 fine
-    local_state.should_receive('shell')\
-      .with_args(re.compile('^ssh'), False, 5, stdin=re.compile('monit'))\
-      .and_return()
 
     # and assume we started the AppController on public1 fine
     local_state.should_receive('shell').with_args(
-      re.compile('^ssh'), False, 5, stdin='service appscale-controller start')
+      re.compile('^ssh'), False, 5, stdin='systemctl start appscale-controller')
 
     # finally, assume the appcontroller comes up after a few tries
     # assume that ssh comes up on the third attempt
@@ -381,13 +372,6 @@ class TestRemoteHelper(unittest.TestCase):
       AppControllerClient.PORT)).and_raise(Exception) \
       .and_raise(Exception).and_return(None)
     socket.should_receive('socket').and_return(fake_socket)
-
-    # Mock out additional remote calls.
-    local_state.should_receive('shell').with_args('ssh -i /root/.appscale/bookey.key -o LogLevel=quiet -o NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no -o UserKnownHostsFile=/dev/null root@public1 ', False, 5, stdin='cp /root/appscale/AppController/scripts/appcontroller /etc/init.d/').and_return()
-
-    local_state.should_receive('shell').with_args('ssh -i /root/.appscale/bookey.key -o LogLevel=quiet -o NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no -o UserKnownHostsFile=/dev/null root@public1 ', False, 5, stdin='chmod +x /etc/init.d/appcontroller').and_return()
-
-    local_state.should_receive('shell').with_args('ssh -i /root/.appscale/boobazblargfoo.key -o LogLevel=quiet -o NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no -o UserKnownHostsFile=/dev/null root@elastic-ip ', False, 5, stdin='chmod +x /etc/init.d/appcontroller').and_return()
 
     RemoteHelper.start_remote_appcontroller('public1', 'bookey', False)
 


### PR DESCRIPTION
Use `systemctl` rather than `service` and remove monit use and clean up that is no longer required.

This change should be merge with related changes for appscale.