### PR TITLE
Making verbose flag optional and using it less

### DIFF
--- a/appscale/tools/appscale.py
+++ b/appscale/tools/appscale.py
@@ -343,7 +343,7 @@ Available commands:
       BadConfigurationException: If the IPs layout was not a dictionary.
     """
     keyname = config['keyname']
-    AppScaleLogger.is_verbose = config.get('verbose', False)
+    verbose = config.get('verbose', False)
 
     if not isinstance(config['ips_layout'], dict) and \
         not isinstance(config['ips_layout'], list):
@@ -368,7 +368,7 @@ Available commands:
       remote_key = '{}/ssh.key'.format(RemoteHelper.CONFIG_DIR)
       try:
         RemoteHelper.scp(
-          head_node.public_ip, keyname, ssh_key_location, remote_key)
+          head_node.public_ip, keyname, ssh_key_location, remote_key, verbose)
       except ShellException:
         return False
 
@@ -377,13 +377,13 @@ Available commands:
           .format(key=remote_key, ip=ip)
         try:
           RemoteHelper.ssh(
-            head_node.public_ip, keyname, ssh_to_ip, user='root')
+            head_node.public_ip, keyname, ssh_to_ip, verbose, user='root')
         except ShellException:
           return False
       return True
 
     for ip in all_ips:
-      if not self.can_ssh_to_ip(ip, keyname):
+      if not self.can_ssh_to_ip(ip, keyname, verbose):
         return False
 
     return True
@@ -408,7 +408,7 @@ Available commands:
       'Invalid IP address in {}'.format(all_ips)
     return all_ips
 
-  def can_ssh_to_ip(self, ip, keyname):
+  def can_ssh_to_ip(self, ip, keyname, is_verbose=None):
     """ Attempts to SSH into the machine located at the given IP address with the
     given SSH key.
 
@@ -416,13 +416,15 @@ Available commands:
       ip: The IP address to attempt to SSH into.
       keyname: The name of the SSH key that uniquely identifies this AppScale
         deployment.
+      is_verbose: A bool that indicates if we should print the SSH command we
+        execute to stdout.
 
     Returns:
       A bool that indicates whether or not the given SSH key can log in without
       a password to the given machine.
     """
     try:
-      RemoteHelper.ssh(ip, keyname, 'ls', user='root')
+      RemoteHelper.ssh(ip, keyname, 'ls', is_verbose, user='root')
       return True
     except ShellException:
       return False

--- a/appscale/tools/appscale.py
+++ b/appscale/tools/appscale.py
@@ -343,7 +343,7 @@ Available commands:
       BadConfigurationException: If the IPs layout was not a dictionary.
     """
     keyname = config['keyname']
-    verbose = config.get('verbose', False)
+    AppScaleLogger.is_verbose = config.get('verbose', False)
 
     if not isinstance(config['ips_layout'], dict) and \
         not isinstance(config['ips_layout'], list):
@@ -368,7 +368,7 @@ Available commands:
       remote_key = '{}/ssh.key'.format(RemoteHelper.CONFIG_DIR)
       try:
         RemoteHelper.scp(
-          head_node.public_ip, keyname, ssh_key_location, remote_key, verbose)
+          head_node.public_ip, keyname, ssh_key_location, remote_key)
       except ShellException:
         return False
 
@@ -377,13 +377,13 @@ Available commands:
           .format(key=remote_key, ip=ip)
         try:
           RemoteHelper.ssh(
-            head_node.public_ip, keyname, ssh_to_ip, verbose, user='root')
+            head_node.public_ip, keyname, ssh_to_ip, user='root')
         except ShellException:
           return False
       return True
 
     for ip in all_ips:
-      if not self.can_ssh_to_ip(ip, keyname, verbose):
+      if not self.can_ssh_to_ip(ip, keyname):
         return False
 
     return True
@@ -408,7 +408,7 @@ Available commands:
       'Invalid IP address in {}'.format(all_ips)
     return all_ips
 
-  def can_ssh_to_ip(self, ip, keyname, is_verbose):
+  def can_ssh_to_ip(self, ip, keyname):
     """ Attempts to SSH into the machine located at the given IP address with the
     given SSH key.
 
@@ -416,15 +416,13 @@ Available commands:
       ip: The IP address to attempt to SSH into.
       keyname: The name of the SSH key that uniquely identifies this AppScale
         deployment.
-      is_verbose: A bool that indicates if we should print the SSH command we
-        execute to stdout.
 
     Returns:
       A bool that indicates whether or not the given SSH key can log in without
       a password to the given machine.
     """
     try:
-      RemoteHelper.ssh(ip, keyname, 'ls', is_verbose, user='root')
+      RemoteHelper.ssh(ip, keyname, 'ls', user='root')
       return True
     except ShellException:
       return False
@@ -585,7 +583,7 @@ Available commands:
     AppScaleTools.update_queues(options.file, options.keyname, options.project)
     try:
       AppScaleTools.update_dispatch(options.file, options.keyname,
-                                    options.project, options.verbose)
+                                    options.project)
     except (AdminError, AppScaleException) as e:
       AppScaleLogger.warn('Request to update dispatch failed, if your '
                           'dispatch references undeployed services, ignore '

--- a/appscale/tools/appscale_logger.py
+++ b/appscale/tools/appscale_logger.py
@@ -1,11 +1,5 @@
-#!/usr/bin/env python
-
-
-# General-purpose Python library imports
 import httplib
 
-
-# Third party library imports
 from termcolor import cprint
 
 
@@ -14,16 +8,15 @@ class AppScaleLogger():
   response, prints them to the user and saves them for debugging purposes.
   """
 
-
   # The location where we remotely dump logs to
   LOGS_HOST = "logs.appscale.com"
 
-
   # The headers necessary for posting data to the remote logs service.
   HEADERS = {
-    'Content-Type' : 'application/x-www-form-urlencoded'
+    'Content-Type': 'application/x-www-form-urlencoded'
   }
 
+  is_verbose = False
 
   @classmethod
   def log(cls, message):
@@ -34,7 +27,6 @@ class AppScaleLogger():
     """
     print message
 
-
   @classmethod
   def warn(cls, message):
     """Prints the specified message with red text as well as to a file.
@@ -43,7 +35,6 @@ class AppScaleLogger():
       message: A str representing the message to warn the user with.
     """
     cprint(message, 'red')
-
 
   @classmethod
   def success(cls, message):
@@ -54,18 +45,15 @@ class AppScaleLogger():
     """
     cprint(message, 'green')
 
-
   @classmethod
-  def verbose(cls, message, is_verbose):
+  def verbose(cls, message):
     """Prints the specified message if we're running in 'verbose' mode, and
     always logs it.
 
     Args:
       message: A str representing the message to log.
-      is_verbose: A bool that indicates whether or not the message should be
-        printed to stdout.
     """
-    if is_verbose:
+    if cls.is_verbose:
       print message
 
 
@@ -101,6 +89,6 @@ class AppScaleLogger():
       conn.close()
     except Exception as exception:
       cls.verbose("Unable to log {0} state: saw exception {1}".format(state,
-        str(exception)), options.verbose)
+        str(exception)))
 
     return params

--- a/appscale/tools/appscale_logger.py
+++ b/appscale/tools/appscale_logger.py
@@ -46,14 +46,16 @@ class AppScaleLogger():
     cprint(message, 'green')
 
   @classmethod
-  def verbose(cls, message):
+  def verbose(cls, message, is_verbose=None):
     """Prints the specified message if we're running in 'verbose' mode, and
     always logs it.
 
     Args:
       message: A str representing the message to log.
+      is_verbose: A bool that indicates whether or not the message should be
+        printed to stdout.
     """
-    if cls.is_verbose:
+    if is_verbose or (is_verbose is None and cls.is_verbose):
       print message
 
 

--- a/appscale/tools/appscale_tools.py
+++ b/appscale/tools/appscale_tools.py
@@ -108,7 +108,7 @@ class AppScaleTools(object):
         ips_to_check.extend(ip_group)
       for ip in ips_to_check:
         # throws a ShellException if the SSH key doesn't work
-        RemoteHelper.ssh(ip, options.keyname, "ls", options.verbose)
+        RemoteHelper.ssh(ip, options.keyname, "ls")
 
     # Finally, find an AppController and send it a message to add
     # the given nodes with the new roles.
@@ -137,15 +137,14 @@ class AppScaleTools(object):
       AppScaleException: If any of the machines named in the ips_layout are
         not running, or do not have the SSH daemon running.
     """
-    LocalState.require_ssh_commands(options.auto, options.verbose)
+    LocalState.require_ssh_commands(options.auto)
     LocalState.make_appscale_directory()
 
     path = LocalState.LOCAL_APPSCALE_PATH + options.keyname
     if options.add_to_existing:
       private_key = path
     else:
-      _, private_key = LocalState.generate_rsa_key(options.keyname,
-        options.verbose)
+      _, private_key = LocalState.generate_rsa_key(options.keyname)
 
     if options.auto:
       if 'root_password' in options:
@@ -162,8 +161,7 @@ class AppScaleTools(object):
     all_ips = [node.public_ip for node in node_layout.nodes]
     for ip in all_ips:
       # first, make sure ssh is actually running on the host machine
-      if not RemoteHelper.is_port_open(ip, RemoteHelper.SSH_PORT,
-        options.verbose):
+      if not RemoteHelper.is_port_open(ip, RemoteHelper.SSH_PORT):
         raise AppScaleException("SSH does not appear to be running at {0}. " \
           "Is the machine at {0} up and running? Make sure your IPs are " \
           "correct!".format(ip))
@@ -172,10 +170,9 @@ class AppScaleTools(object):
       AppScaleLogger.log("Executing ssh-copy-id for host: {0}".format(ip))
       if options.auto:
         LocalState.shell("{0} root@{1} {2} {3}".format(cls.EXPECT_SCRIPT, ip,
-          private_key, password), options.verbose)
+          private_key, password))
       else:
-        LocalState.shell("ssh-copy-id -i {0} root@{1}".format(private_key, ip),
-          options.verbose)
+        LocalState.shell("ssh-copy-id -i {0} root@{1}".format(private_key, ip))
 
     AppScaleLogger.success("Generated a new SSH key for this deployment " + \
       "at {0}".format(private_key))
@@ -212,7 +209,7 @@ class AppScaleTools(object):
     nodes = [NodeStats(ip, node) for ip, node in node_stats.iteritems() if node]
     invisible_nodes = [ip for ip, node in node_stats.iteritems() if not node]
 
-    if options.verbose:
+    if AppScaleLogger.is_verbose:
       AppScaleLogger.log("-"*76)
       cls._print_nodes_info(nodes, invisible_nodes)
       cls._print_roles_info(nodes)
@@ -482,16 +479,14 @@ class AppScaleTools(object):
 
         try:
           RemoteHelper.scp_remote_to_local(
-            public_ip, options.keyname, log_path['remote'],
-            sub_dir, options.verbose
+            public_ip, options.keyname, log_path['remote'], sub_dir
           )
         except ShellException as shell_exception:
           failures = True
           AppScaleLogger.warn('Unable to collect logs from {} for host {}'.
                               format(log_path['remote'], public_ip))
           AppScaleLogger.verbose(
-            'Encountered exception: {}'.format(str(shell_exception)),
-            options.verbose)
+            'Encountered exception: {}'.format(str(shell_exception)))
 
     if failures:
       AppScaleLogger.log("Done copying to {}. There were failures while "
@@ -555,8 +550,7 @@ class AppScaleTools(object):
     AppScaleLogger.success(
       'Successfully issued request to move {0} to ports {1} and {2}'.format(
         options.appname, options.http_port, options.https_port))
-    RemoteHelper.sleep_until_port_is_open(
-      login_host, options.http_port, options.verbose)
+    RemoteHelper.sleep_until_port_is_open(login_host, options.http_port)
     AppScaleLogger.success(
       'Your app serves unencrypted traffic at: http://{0}:{1}'.format(
         login_host, options.http_port))
@@ -799,19 +793,18 @@ class AppScaleTools(object):
 
       # Enables root logins and SSH access on the head node.
       RemoteHelper.enable_root_ssh(options, head_node.public_ip)
-    AppScaleLogger.verbose("Node Layout: {}".format(node_layout.to_list()),
-                           options.verbose)
+    AppScaleLogger.verbose("Node Layout: {}".format(node_layout.to_list()))
 
     # Ensure all nodes are compatible.
     RemoteHelper.ensure_machine_is_compatible(
-      head_node.public_ip, options.keyname, options.verbose)
+      head_node.public_ip, options.keyname)
 
     # Use rsync to move custom code into the deployment.
     if options.rsync_source:
       AppScaleLogger.log("Copying over local copy of AppScale from {0}".
         format(options.rsync_source))
       RemoteHelper.rsync_files(head_node.public_ip, options.keyname,
-                               options.rsync_source, options.verbose)
+                               options.rsync_source)
 
     # Start services on head node.
     RemoteHelper.start_head_node(options, my_id, node_layout)
@@ -823,7 +816,7 @@ class AppScaleTools(object):
 
     # Copy the locations.json to the head node
     RemoteHelper.copy_local_metadata(node_layout.head_node().public_ip,
-                                     options.keyname, options.verbose)
+                                     options.keyname)
 
     # Wait for services on head node to start.
     secret_key = LocalState.get_secret_key(options.keyname)
@@ -838,7 +831,7 @@ class AppScaleTools(object):
       AppScaleLogger.warn('Unable to initialize AppController: {}'.
                           format(socket_error.message))
       message = RemoteHelper.collect_appcontroller_crashlog(
-        head_node, options.keyname, options.verbose)
+        head_node, options.keyname)
       raise AppControllerException(message)
 
     # Set up admin account.
@@ -872,7 +865,7 @@ class AppScaleTools(object):
       raise AppControllerException('login property not found')
 
     RemoteHelper.sleep_until_port_is_open(
-      login_host, RemoteHelper.APP_DASHBOARD_PORT, options.verbose)
+      login_host, RemoteHelper.APP_DASHBOARD_PORT)
 
     AppScaleLogger.success("AppScale successfully started!")
     AppScaleLogger.success(
@@ -925,8 +918,7 @@ class AppScaleTools(object):
     # Stop gracefully the AppScale deployment.
     try:
       RemoteHelper.terminate_virtualized_cluster(options.keyname,
-                                                 options.clean,
-                                                 options.verbose)
+                                                 options.clean)
     except (IOError, AppScaleException, AppControllerException,
             BadConfigurationException) as e:
       if not (infrastructure in InfrastructureAgentFactory.VALID_AGENTS and
@@ -936,7 +928,7 @@ class AppScaleTools(object):
       if options.test:
         AppScaleLogger.warn(e)
       else:
-        AppScaleLogger.verbose(e, options.verbose)
+        AppScaleLogger.verbose(e)
         if isinstance(e, AppControllerException):
           response = raw_input(
             'AppScale may not have shut down properly, are you sure you want '
@@ -954,8 +946,7 @@ class AppScaleTools(object):
     # asked.
     if (infrastructure in InfrastructureAgentFactory.VALID_AGENTS and
           options.terminate):
-      RemoteHelper.terminate_cloud_infrastructure(options.keyname,
-        options.verbose)
+      RemoteHelper.terminate_cloud_infrastructure(options.keyname)
     elif infrastructure in InfrastructureAgentFactory.VALID_AGENTS and not \
         options.terminate:
       AppScaleLogger.log("AppScale did not terminate any of your cloud "
@@ -978,13 +969,11 @@ class AppScaleTools(object):
     """
     custom_service_yaml = None
     if cls.TAR_GZ_REGEX.search(options.file):
-      file_location = LocalState.extract_tgz_app_to_dir(options.file,
-        options.verbose)
+      file_location = LocalState.extract_tgz_app_to_dir(options.file)
       created_dir = True
       version = Version.from_tar_gz(options.file)
     elif cls.ZIP_REGEX.search(options.file):
-      file_location = LocalState.extract_zip_app_to_dir(options.file,
-        options.verbose)
+      file_location = LocalState.extract_zip_app_to_dir(options.file)
       created_dir = True
       version = Version.from_zip(options.file)
     elif os.path.isdir(options.file):
@@ -1038,7 +1027,7 @@ class AppScaleTools(object):
     admin_client = AdminClient(head_node_public_ip, secret_key)
 
     remote_file_path = RemoteHelper.copy_app_to_host(
-      file_location, version.project_id, options.keyname, options.verbose,
+      file_location, version.project_id, options.keyname,
       extras, custom_service_yaml)
 
     AppScaleLogger.log(
@@ -1077,7 +1066,7 @@ class AppScaleTools(object):
 
 
   @classmethod
-  def update_dispatch(cls, source_location, keyname, project_id, is_verbose):
+  def update_dispatch(cls, source_location, keyname, project_id):
     """ Updates an application's dispatch routing rules from the configuration
       file.
 
@@ -1134,7 +1123,7 @@ class AppScaleTools(object):
 
     AppScaleLogger.verbose(
         "The following dispatchRules have been applied to your application's "
-        "configuration : {}".format(dispatch_rules), is_verbose)
+        "configuration : {}".format(dispatch_rules))
     AppScaleLogger.success('Dispatch has been updated for {}'.format(
         version.project_id))
 

--- a/appscale/tools/appscale_tools.py
+++ b/appscale/tools/appscale_tools.py
@@ -122,8 +122,7 @@ class AppScaleTools(object):
     # TODO(cgb): Should we wait for the new instances to come up and get
     # initialized?
     AppScaleLogger.success("Successfully sent request to add instances " + \
-      "to this AppScale deployment.")
-
+                           "to this AppScale deployment.")
 
   @classmethod
   def add_keypair(cls, options):
@@ -209,7 +208,7 @@ class AppScaleTools(object):
     nodes = [NodeStats(ip, node) for ip, node in node_stats.iteritems() if node]
     invisible_nodes = [ip for ip, node in node_stats.iteritems() if not node]
 
-    if AppScaleLogger.is_verbose:
+    if options.verbose:
       AppScaleLogger.log("-"*76)
       cls._print_nodes_info(nodes, invisible_nodes)
       cls._print_roles_info(nodes)

--- a/appscale/tools/parse_args.py
+++ b/appscale/tools/parse_args.py
@@ -14,6 +14,8 @@ import yaml
 
 
 # AppScale-specific imports
+from appscale.tools.appscale_logger import AppScaleLogger
+
 try:
   from appscale.agents.azure_agent import AzureAgent
 except ImportError:
@@ -164,6 +166,7 @@ class ParseArgs(object):
     if self.args.version:
       raise SystemExit(APPSCALE_VERSION)
 
+    AppScaleLogger.is_verbose = self.args.verbose
     self.validate_allowed_flags(function)
 
 

--- a/test/test_appscale_run_instances.py
+++ b/test/test_appscale_run_instances.py
@@ -268,7 +268,7 @@ EC2_SECRET_KEY: 'baz'
       with_args("ssh -i /root/.appscale/boobazblargfoo.key -o LogLevel=quiet "
                 "-o NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no "
                 "-o UserKnownHostsFile=/dev/null root@public1 ",
-                False, 5,
+                None, 5,
                 stdin="cp /root/appscale/AppController/scripts/appcontroller "
                       "/etc/init.d/")
 
@@ -276,13 +276,13 @@ EC2_SECRET_KEY: 'baz'
       with_args("ssh -i /root/.appscale/boobazblargfoo.key -o LogLevel=quiet "
                 "-o NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no "
                 "-o UserKnownHostsFile=/dev/null root@{} ".format(IP_1),
-                False, 5, stdin="chmod +x /etc/init.d/appcontroller")
+                None, 5, stdin="chmod +x /etc/init.d/appcontroller")
 
     self.local_state.should_receive('shell').\
       with_args("ssh -i /root/.appscale/boobazblargfoo.key -o LogLevel=quiet "
                 "-o NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no "
                 "-o UserKnownHostsFile=/dev/null root@public1 ",
-                False, 5,
+                None, 5,
                 stdin="cp /root/appscale/AppController/scripts/appcontroller "
                       "/etc/init.d/")
 
@@ -322,33 +322,33 @@ EC2_SECRET_KEY: 'baz'
 
     # mock out copying over the keys
     self.local_state.should_receive('shell')\
-      .with_args(re.compile('^scp .*.key'),False,5)
+      .with_args(re.compile('^scp .*.key'), None, 5)
 
     self.setup_appscale_compatibility_mocks()
 
     # mock out generating the private key
     self.local_state.should_receive('shell')\
-      .with_args(re.compile('^openssl'),False,stdin=None)\
+      .with_args(re.compile('^openssl'), None, stdin=None)\
       .and_return()
 
     # mock out removing the old json file
     self.local_state.should_receive('shell')\
-      .with_args(re.compile('^ssh'),False,5,stdin=re.compile('rm -rf'))\
+      .with_args(re.compile('^ssh'), None, 5, stdin=re.compile('rm -rf'))\
       .and_return()
 
     # assume that we started monit fine
     self.local_state.should_receive('shell')\
-      .with_args(re.compile('^ssh'),False,5,stdin=re.compile('monit'))\
+      .with_args(re.compile('^ssh'), None, 5, stdin=re.compile('monit'))\
       .and_return()
 
     self.local_state.should_receive('shell').with_args(
-      re.compile('^ssh'), False, 5, stdin='service appscale-controller start')
+      re.compile('^ssh'), None, 5, stdin='service appscale-controller start')
 
     self.local_state.should_receive('shell').\
       with_args('ssh -i /root/.appscale/boobazblargfoo.key -o LogLevel=quiet '
                 '-o NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no '
                 '-o UserKnownHostsFile=/dev/null root@{} '.format(IP_1),
-                False, 5,
+                None, 5,
                 stdin='cp /root/appscale/AppController/scripts/appcontroller /etc/init.d/').and_return()
 
     self.setup_socket_mocks(IP_1)
@@ -366,23 +366,23 @@ EC2_SECRET_KEY: 'baz'
     locations_file = '{}/locations-bookey.yaml'.\
       format(RemoteHelper.CONFIG_DIR)
     self.local_state.should_receive('shell')\
-      .with_args(re.compile('^scp .*{}'.format(locations_file)), False, 5)\
+      .with_args(re.compile('^scp .*{}'.format(locations_file)), None, 5)\
       .and_return()
 
     locations_json = '{}/locations-bookey.json'.\
       format(RemoteHelper.CONFIG_DIR)
     self.local_state.should_receive('shell')\
-      .with_args(re.compile('^scp .*{}'.format(locations_json)), False, 5)\
+      .with_args(re.compile('^scp .*{}'.format(locations_json)), None, 5)\
       .and_return()
 
     user_locations = '/root/.appscale/locations-bookey.json'
     self.local_state.should_receive('shell')\
-      .with_args(re.compile('^scp .*{}'.format(user_locations)), False, 5)\
+      .with_args(re.compile('^scp .*{}'.format(user_locations)), None, 5)\
       .and_return()
 
     # Assume the secret key was copied successfully.
     self.local_state.should_receive('shell')\
-      .with_args(re.compile('^scp .*.secret'), False, 5)\
+      .with_args(re.compile('^scp .*.secret'), None, 5)\
       .and_return()
 
     flexmock(AppControllerClient)
@@ -468,30 +468,30 @@ EC2_SECRET_KEY: 'baz'
 
     # assume that root login is not enabled
     self.local_state.should_receive('shell').with_args(re.compile('ssh'),
-      False, 5, stdin='ls').and_return(
+      None, 5, stdin='ls').and_return(
       'Please login as the user "ubuntu" rather than the user "root"')
 
     # assume that we can enable root login
     self.local_state.should_receive('shell').with_args(
-      re.compile('ssh'), False, 5,
+      re.compile('ssh'), None, 5,
       stdin='sudo touch /root/.ssh/authorized_keys').and_return()
 
     self.local_state.should_receive('shell').with_args(
-      re.compile('ssh'), False, 5,
+      re.compile('ssh'), None, 5,
       stdin='sudo chmod 600 /root/.ssh/authorized_keys').and_return()
 
     self.local_state.should_receive('shell').with_args(
-      re.compile('ssh'), False, 5, stdin='mktemp').and_return()
+      re.compile('ssh'), None, 5, stdin='mktemp').and_return()
 
     self.local_state.should_receive('shell').with_args(
-      re.compile('ssh'), False, 5,
+      re.compile('ssh'), None, 5,
       stdin=re.compile(
         'sudo sort -u ~/.ssh/authorized_keys /root/.ssh/authorized_keys -o '
       )
     ).and_return()
 
     self.local_state.should_receive('shell').with_args(
-      re.compile('ssh'), False, 5,
+      re.compile('ssh'), None, 5,
       stdin=re.compile(
         'sudo sed -n '
         '\'\/\.\*Please login\/d; w\/root\/\.ssh\/authorized_keys\' '
@@ -499,21 +499,23 @@ EC2_SECRET_KEY: 'baz'
     ).and_return()
 
     self.local_state.should_receive('shell').with_args(
-      re.compile('ssh'), False, 5, stdin=re.compile('rm -f ')
+      re.compile('ssh'), None, 5, stdin=re.compile('rm -f ')
+    ).and_return()
+    self.local_state.should_receive('shell').with_args(
+      re.compile('ssh'), None, 5, stdin=re.compile('rm -rf ')
     ).and_return()
 
     # and assume that we can copy over our ssh keys fine
     self.local_state.should_receive('shell').\
-      with_args(re.compile('scp .*[r|d]sa'), False, 5).and_return()
+      with_args(re.compile('scp .*[r|d]sa'), None, 5).and_return()
     self.local_state.should_receive('shell').\
-      with_args(re.compile('scp .*{0}'.format(self.keyname)), False, 5).\
+      with_args(re.compile('scp .*{0}'.format(self.keyname)), None, 5).\
       and_return()
 
     self.local_state.should_receive('shell').\
       with_args('ssh -i /root/.appscale/bookey.key -o LogLevel=quiet -o '
                 'NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no '
-                '-o UserKnownHostsFile=/dev/null root@public1 ',
-                False, 5,
+                '-o UserKnownHostsFile=/dev/null root@public1 ', None, 5,
                 stdin='cp /root/appscale/AppController/scripts/appcontroller '
                       '/etc/init.d/').\
       and_return()
@@ -521,8 +523,7 @@ EC2_SECRET_KEY: 'baz'
     self.local_state.should_receive('shell').\
       with_args('ssh -i /root/.appscale/boobazblargfoo.key -o LogLevel=quiet '
                 '-o NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no '
-                '-o UserKnownHostsFile=/dev/null root@elastic-ip ',
-                False, 5,
+                '-o UserKnownHostsFile=/dev/null root@elastic-ip ', None, 5,
                 stdin='cp /root/appscale/AppController/scripts/appcontroller '
                       '/etc/init.d/').\
       and_return()
@@ -530,22 +531,22 @@ EC2_SECRET_KEY: 'baz'
     self.local_state.should_receive('shell').\
       with_args('ssh -i /root/.appscale/boobazblargfoo.key -o LogLevel=quiet '
                 '-o NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no '
-                '-o UserKnownHostsFile=/dev/null root@elastic-ip ',
-                False, 5, stdin='chmod +x /etc/init.d/appcontroller').\
+                '-o UserKnownHostsFile=/dev/null root@elastic-ip ', None, 5,
+                stdin='chmod +x /etc/init.d/appcontroller').\
       and_return()
 
     self.setup_appscale_compatibility_mocks()
 
     # mock out generating the private key
     self.local_state.should_receive('shell').with_args(re.compile('openssl'),
-      False, stdin=None)
+      stdin=None)
 
     # assume that we started monit fine
     self.local_state.should_receive('shell').with_args(re.compile('ssh'),
-      False, 5, stdin=re.compile('monit'))
+      None, 5, stdin=re.compile('monit'))
 
     self.local_state.should_receive('shell').with_args(
-      re.compile('^ssh'), False, 5, stdin='service appscale-controller start')
+      re.compile('^ssh'), None, 5, stdin='service appscale-controller start')
 
     self.setup_socket_mocks('elastic-ip')
     self.setup_appcontroller_mocks('elastic-ip', 'private1')
@@ -560,11 +561,11 @@ EC2_SECRET_KEY: 'baz'
 
     # copying over the locations yaml and json files should be fine
     self.local_state.should_receive('shell').with_args(re.compile('scp'),
-      False, 5, stdin=re.compile('locations-{0}'.format(self.keyname)))
+      None, 5, stdin=re.compile('locations-{0}'.format(self.keyname)))
 
     # same for the secret key
     self.local_state.should_receive('shell').with_args(re.compile('scp'),
-      False, 5, stdin=re.compile('{0}.secret'.format(self.keyname)))
+      None, 5, stdin=re.compile('{0}.secret'.format(self.keyname)))
 
     flexmock(RemoteHelper).should_receive('copy_deployment_credentials')
     flexmock(AppControllerClient)
@@ -656,30 +657,30 @@ EC2_SECRET_KEY: 'baz'
 
     # assume that root login is not enabled
     self.local_state.should_receive('shell').with_args(re.compile('ssh'),
-      False, 5, stdin='ls').and_return(
+      None, 5, stdin='ls').and_return(
       'Please login as the user "ubuntu" rather than the user "root"')
 
     # assume that we can enable root login
     self.local_state.should_receive('shell').with_args(
-      re.compile('ssh'), False, 5,
+      re.compile('ssh'), None, 5,
       stdin='sudo touch /root/.ssh/authorized_keys').and_return()
 
     self.local_state.should_receive('shell').with_args(
-      re.compile('ssh'), False, 5,
+      re.compile('ssh'), None, 5,
       stdin='sudo chmod 600 /root/.ssh/authorized_keys').and_return()
 
     self.local_state.should_receive('shell').with_args(
-      re.compile('ssh'), False, 5, stdin='mktemp').and_return()
+      re.compile('ssh'), None, 5, stdin='mktemp').and_return()
 
     self.local_state.should_receive('shell').with_args(
-      re.compile('ssh'), False, 5,
+      re.compile('ssh'), None, 5,
       stdin=re.compile(
         'sudo sort -u ~/.ssh/authorized_keys /root/.ssh/authorized_keys -o '
       )
     ).and_return()
 
     self.local_state.should_receive('shell').with_args(
-      re.compile('ssh'), False, 5,
+      re.compile('ssh'), None, 5,
       stdin=re.compile(
         'sudo sed -n '
         '\'\/\.\*Please login\/d; w\/root\/\.ssh\/authorized_keys\' '
@@ -687,27 +688,30 @@ EC2_SECRET_KEY: 'baz'
     ).and_return()
 
     self.local_state.should_receive('shell').with_args(
-      re.compile('ssh'), False, 5, stdin=re.compile('rm -f ')
+      re.compile('ssh'), None, 5, stdin=re.compile('rm -f ')
+    ).and_return()
+    self.local_state.should_receive('shell').with_args(
+      re.compile('ssh'), None, 5, stdin=re.compile('rm -rf ')
     ).and_return()
 
     # and assume that we can copy over our ssh keys fine
     self.local_state.should_receive('shell').with_args(re.compile('scp .*[r|d]sa'),
-      False, 5).and_return()
+      None, 5).and_return()
     self.local_state.should_receive('shell').with_args(re.compile('scp .*{0}'
-      .format(self.keyname)), False, 5).and_return()
+      .format(self.keyname)), None, 5).and_return()
 
     self.setup_appscale_compatibility_mocks()
 
     # mock out generating the private key
     self.local_state.should_receive('shell').with_args(re.compile('openssl'),
-      False, stdin=None)
+      None, stdin=None)
 
     # assume that we started monit fine
     self.local_state.should_receive('shell').with_args(re.compile('ssh'),
-      False, 5, stdin=re.compile('monit'))
+      None, 5, stdin=re.compile('monit'))
 
     self.local_state.should_receive('shell').with_args(
-      re.compile('^ssh'), False, 5, stdin='service appscale-controller start')
+      re.compile('^ssh'), None, 5, stdin='service appscale-controller start')
 
     self.setup_socket_mocks('public1')
     self.setup_appcontroller_mocks('public1', 'private1')
@@ -722,21 +726,46 @@ EC2_SECRET_KEY: 'baz'
 
     # copying over the locations json file should be fine
     self.local_state.should_receive('shell').with_args(re.compile('scp'),
-      False, 5, stdin=re.compile('locations-{0}'.format(self.keyname)))
+      None, 5, stdin=re.compile('locations-{0}'.format(self.keyname)))
 
     # same for the secret key
     self.local_state.should_receive('shell').with_args(re.compile('scp'),
-      False, 5, stdin=re.compile('{0}.secret'.format(self.keyname)))
+      None, 5, stdin=re.compile('{0}.secret'.format(self.keyname)))
 
-    self.local_state.should_receive('shell').with_args('ssh -i /root/.appscale/boobazbargfoo.key -o LogLevel=quiet -o NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no -o UserKnownHostsFile=/dev/null root@public1 ', False, 5, stdin='cp /root/appscale/AppController/scripts/appcontroller /etc/init.d/').and_return()
+    self.local_state.should_receive('shell').with_args(
+      'ssh -i /root/.appscale/boobazbargfoo.key -o LogLevel=quiet '
+      '-o NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no '
+      '-o UserKnownHostsFile=/dev/null root@public1 ', None, 5,
+      stdin='cp /root/appscale/AppController/scripts/appcontroller /etc/init.d/'
+    ).and_return()
 
-    self.local_state.should_receive('shell').with_args('ssh -i /root/.appscale/boobazblargfoo.key -o LogLevel=quiet -o NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no -o UserKnownHostsFile=/dev/null root@elastic-ip ', False, 5, stdin='cp /root/appscale/AppController/scripts/appcontroller /etc/init.d/').and_return()
+    self.local_state.should_receive('shell').with_args(
+      'ssh -i /root/.appscale/boobazblargfoo.key -o LogLevel=quiet '
+      '-o NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no '
+      '-o UserKnownHostsFile=/dev/null root@elastic-ip ', None, 5,
+      stdin='cp /root/appscale/AppController/scripts/appcontroller /etc/init.d/'
+    ).and_return()
 
-    self.local_state.should_receive('shell').with_args('ssh -i /root/.appscale/boobazblargfoo.key -o LogLevel=quiet -o NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no -o UserKnownHostsFile=/dev/null root@elastic-ip ', False, 5, stdin='chmod +x /etc/init.d/appcontroller').and_return()
+    self.local_state.should_receive('shell').with_args(
+      'ssh -i /root/.appscale/boobazblargfoo.key -o LogLevel=quiet '
+      '-o NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no '
+      '-o UserKnownHostsFile=/dev/null root@elastic-ip ', None, 5,
+      stdin='chmod +x /etc/init.d/appcontroller'
+    ).and_return()
 
-    self.local_state.should_receive('shell').with_args('ssh -i /root/.appscale/boobazblargfoo.key -o LogLevel=quiet -o NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no -o UserKnownHostsFile=/dev/null root@public1 ', False, 5, stdin='cp /root/appscale/AppController/scripts/appcontroller /etc/init.d/')
+    self.local_state.should_receive('shell').with_args(
+      'ssh -i /root/.appscale/boobazblargfoo.key -o LogLevel=quiet '
+      '-o NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no '
+      '-o UserKnownHostsFile=/dev/null root@public1 ', None, 5,
+      stdin='cp /root/appscale/AppController/scripts/appcontroller /etc/init.d/'
+    ).and_return()
 
-    self.local_state.should_receive('shell').with_args('ssh -i /root/.appscale/boobazblargfoo.key -o LogLevel=quiet -o NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no -o UserKnownHostsFile=/dev/null root@public1 ', False, 5, stdin='chmod +x /etc/init.d/appcontroller').and_return()
+    self.local_state.should_receive('shell').with_args(
+      'ssh -i /root/.appscale/boobazblargfoo.key -o LogLevel=quiet '
+      '-o NumberOfPasswordPrompts=0 -o StrictHostkeyChecking=no '
+      '-o UserKnownHostsFile=/dev/null root@public1 ', None, 5,
+      stdin='chmod +x /etc/init.d/appcontroller'
+    ).and_return()
 
     flexmock(RemoteHelper).should_receive('copy_deployment_credentials')
     flexmock(AppControllerClient)

--- a/test/test_appscale_upload_app.py
+++ b/test/test_appscale_upload_app.py
@@ -260,7 +260,7 @@ class TestAppScaleUploadApp(unittest.TestCase):
       and_return(head_node)
     flexmock(LocalState).should_receive('get_secret_key').and_return(secret)
     flexmock(RemoteHelper).should_receive('copy_app_to_host').\
-      with_args(extracted_dir, app_id, self.keyname, False, {}, None).\
+      with_args(extracted_dir, app_id, self.keyname, {}, None).\
       and_return(source_path)
     flexmock(AdminClient).should_receive('create_version').\
       and_return(operation_id)

--- a/test/test_remote_helper.py
+++ b/test/test_remote_helper.py
@@ -277,12 +277,12 @@ class TestRemoteHelper(unittest.TestCase):
     flexmock(RemoteHelper).\
       should_receive('run_user_commands').\
       with_args('some IP', self.options.user_commands,
-                self.options.keyname, self.options.verbose).\
+                self.options.keyname).\
       and_return()
 
     flexmock(RemoteHelper).\
       should_receive('start_remote_appcontroller').\
-      with_args('some IP', self.options.keyname, self.options.verbose).\
+      with_args('some IP', self.options.keyname).\
       and_return()
 
     layout = {}


### PR DESCRIPTION
Verbose flag is often passed all the way from command line argument to the very low level functions.
It's not nice.
This branch makes verbose flag optional for majority of usages. And now verbosity can be set globally.