### PR TITLE
Use keyword params for copy_app_to_host

### DIFF
--- a/appscale/tools/appscale_tools.py
+++ b/appscale/tools/appscale_tools.py
@@ -1026,7 +1026,7 @@ class AppScaleTools(object):
 
     remote_file_path = RemoteHelper.copy_app_to_host(
       file_location, version.project_id, options.keyname,
-      extras, custom_service_yaml)
+      extras=extras, custom_service_yaml=custom_service_yaml)
 
     AppScaleLogger.log(
       'Deploying service {} for {}'.format(version.service_id,

--- a/test/test_appscale_upload_app.py
+++ b/test/test_appscale_upload_app.py
@@ -260,7 +260,7 @@ class TestAppScaleUploadApp(unittest.TestCase):
       and_return(head_node)
     flexmock(LocalState).should_receive('get_secret_key').and_return(secret)
     flexmock(RemoteHelper).should_receive('copy_app_to_host').\
-      with_args(extracted_dir, app_id, self.keyname, {}, None).\
+      with_args(extracted_dir, app_id, self.keyname, None, {}, None).\
       and_return(source_path)
     flexmock(AdminClient).should_receive('create_version').\
       and_return(operation_id)

--- a/test/test_appscale_upload_app.py
+++ b/test/test_appscale_upload_app.py
@@ -260,7 +260,7 @@ class TestAppScaleUploadApp(unittest.TestCase):
       and_return(head_node)
     flexmock(LocalState).should_receive('get_secret_key').and_return(secret)
     flexmock(RemoteHelper).should_receive('copy_app_to_host').\
-      with_args(extracted_dir, app_id, self.keyname, None, {}, None).\
+      with_args(extracted_dir, app_id, self.keyname, extras={}, custom_service_yaml=None).\
       and_return(source_path)
     flexmock(AdminClient).should_receive('create_version').\
       and_return(operation_id)


### PR DESCRIPTION
Method signature in remote_helper https://github.com/AppScale/appscale-tools/blob/master/appscale/tools/remote_helper.py#L1079-L1080